### PR TITLE
Go r60.3 compatibility fix

### DIFF
--- a/src/pkg/walk/webview_ioleinplaceframe.go
+++ b/src/pkg/walk/webview_ioleinplaceframe.go
@@ -95,6 +95,6 @@ func webView_IOleInPlaceFrame_EnableModeless(inPlaceFrame *webViewIOleInPlaceFra
 	return S_OK
 }
 
-func webView_IOleInPlaceFrame_TranslateAccelerator(inPlaceFrame *webViewIOleInPlaceFrame, lpmsg *MSG, wID uint16) HRESULT {
+func webView_IOleInPlaceFrame_TranslateAccelerator(inPlaceFrame *webViewIOleInPlaceFrame, lpmsg *MSG, wID uint32) HRESULT {
 	return E_NOTIMPL
 }

--- a/src/pkg/walk/webview_ioleinplacesite.go
+++ b/src/pkg/walk/webview_ioleinplacesite.go
@@ -91,7 +91,7 @@ func webView_IOleInPlaceSite_GetWindowContext(inPlaceSite *webViewIOleInPlaceSit
 	return S_OK
 }
 
-func webView_IOleInPlaceSite_Scroll(inPlaceSite *webViewIOleInPlaceSite, scrollExtent SIZE) HRESULT {
+func webView_IOleInPlaceSite_Scroll(inPlaceSite *webViewIOleInPlaceSite, scrollExtentX int32, scrollExtentY int32) HRESULT {
 	return E_NOTIMPL
 }
 


### PR DESCRIPTION
Hi lxn,

I tried to check out and run WALK the other day with the latest Go release (not the experimental), but it didn't work. After working on it and posting a message to the golang-nuts board, I found a solution which allows the examples from walk to compile and run fine with the latest r60.3 Go release.

The changes were suggested by Alex "brainman" in this thread: http://groups.google.com/group/golang-nuts/browse_thread/thread/6018c158fce537d

I have tested the changes on my own machine, and have had no issues compiling or running the examples, so this does fix the runtime panic problem I was having. The original problem was that go has had some additional runtime checks added earlier this year to check parameter sizes, and apparently WALK wasn't compliant with this particular check. I don't fully understand the WALK code, or how these changes may affect other parts of the code, so some caution is advised before accepting these changes.
- Nick
