### PR TITLE
add walk.MustRegisterWindowClassWithWndProcPtr to support supper classing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Mateusz Czapliński <czapkofan@gmail.com>
 Michael Teichgräber <mteichgraeber@gmx.de>
 Tim Dufrane <tim.dufrane@gmail.com>
 Vincent Vanackere <vincent.vanackere@gmail.com>
+Shawn Sun <datago@yeah.net>

--- a/window.go
+++ b/window.go
@@ -290,6 +290,10 @@ var (
 // InitWidget. Calling MustRegisterWindowClass twice with the same className
 // results in a panic.
 func MustRegisterWindowClass(className string) {
+	MustRegisterWindowClassWithWndProcPtr(className, defaultWndProcPtr)
+}
+
+func MustRegisterWindowClassWithWndProcPtr(className string, wndProcPtr uintptr) {
 	if registeredWindowClasses[className] {
 		panic("window class already registered")
 	}
@@ -311,7 +315,7 @@ func MustRegisterWindowClass(className string) {
 
 	var wc win.WNDCLASSEX
 	wc.CbSize = uint32(unsafe.Sizeof(wc))
-	wc.LpfnWndProc = defaultWndProcPtr
+	wc.LpfnWndProc = wndProcPtr
 	wc.HInstance = hInst
 	wc.HIcon = hIcon
 	wc.HCursor = hCursor


### PR DESCRIPTION
add walk.MustRegisterWindowClassWithWndProcPtr to support supper classing

and thus to sovle issue https://github.com/lxn/walk/issues/140

for example: https://github.com/Archs/go-sciter/blob/master/sciterwidget/sciterwidget.go#L82