### PR TITLE
Remove the nonwin.go file because it causes a problem with GoDoc. 

### DIFF
--- a/nonwin.go
+++ b/nonwin.go
@@ -1,7 +1,0 @@
-// Copyright 2010 The win Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// +build !windows
-
-package walk


### PR DESCRIPTION
GoDoc will default to GOOS=linux, so when this file is present, the package becomes empty.  Changing it to a windows only package fixes the issue.