### PR TITLE
ToolTip improvements

### DIFF
--- a/numberedit.go
+++ b/numberedit.go
@@ -729,3 +729,7 @@ func (nle *numberLineEdit) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uin
 
 	return nle.LineEdit.WndProc(hwnd, msg, wParam, lParam)
 }
+
+func (ne *NumberEdit) SetToolTipText(s string) error {
+	return ne.edit.SetToolTipText(s)
+}


### PR DESCRIPTION
This pull request addresses the following bugs:

1. Tooltips don't work with NumberEdit.
2. Tooltips limit the maximum text size.

The solution for the second needs further testing. Specifically, it can result in random crashes if a long text is added to the tooltip by some means other than ToolTip.SetText(). This should not be a problem for the globalToolTip of walk, because all code paths were verified.