### PR TITLE
To add the mouse wheel event processing for WindowBase

### DIFF
--- a/mouseevent.go
+++ b/mouseevent.go
@@ -55,3 +55,11 @@ func (p *MouseEventPublisher) Publish(x, y int, button MouseButton) {
 		}
 	}
 }
+
+func MouseWheelEventDelta(button MouseButton) int {
+	return int(int32(button) >> 16)
+}
+
+func MouseWheelEventKeyState(button MouseButton) int {
+	return int(int32(button) & 0xFFFF)
+}


### PR DESCRIPTION
Example:
```go
textEdit.MouseWheel().Attach(func (x, y int, button walk.MouseButton) {
	delta := walk.MouseWheelEventDelta(button)
	keyState := walk.MouseWheelEventKeyState(button)
	fmt.Printf("x = %d, y = %d, delta = %d, keyState = %d\n",x, y, delta, keyState)
	 //todo other
})
```