### PR TITLE
CustomWidget: add missing SetViewportOrgEx call

### DIFF
--- a/customwidget.go
+++ b/customwidget.go
@@ -177,6 +177,9 @@ func (cw *CustomWidget) bufferedPaint(canvas *Canvas, updateBounds Rectangle) er
 	}
 	defer win.SelectObject(buffered.hdc, oldbmp)
 
+	win.SetViewportOrgEx(buffered.hdc, -int32(updateBounds.X), -int32(updateBounds.Y), nil)
+	win.SetBrushOrgEx(buffered.hdc, -int32(updateBounds.X), -int32(updateBounds.Y), nil)
+
 	err := cw.paint(&buffered, updateBounds)
 
 	if !win.BitBlt(canvas.hdc,

--- a/declarative/combobox.go
+++ b/declarative/combobox.go
@@ -47,6 +47,7 @@ type ComboBox struct {
 	Value                 Property
 	CurrentIndex          Property
 	OnCurrentIndexChanged walk.EventHandler
+	OnTextChanged         walk.EventHandler
 }
 
 func (cb ComboBox) Create(builder *Builder) error {


### PR DESCRIPTION
The viewport origin should be adjusted for a partial update, specifically
when updateBounds Rectangle is not at the origin.