### PR TITLE
TextEdit horizontal scrollbar added

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Michael Teichgräber <mteichgraeber@gmx.de>
 Shawn Sun <datago@yeah.net>
 Tim Dufrane <tim.dufrane@gmail.com>
 Vincent Vanackere <vincent.vanackere@gmail.com>
+Paul Wolf <paul.wolf23@gmail.com>

--- a/declarative/textedit.go
+++ b/declarative/textedit.go
@@ -46,6 +46,8 @@ type TextEdit struct {
 	MaxLength int
 	ReadOnly  Property
 	Text      Property
+	HScroll   bool
+	VScroll   bool
 }
 
 func (te TextEdit) Create(builder *Builder) error {
@@ -53,6 +55,8 @@ func (te TextEdit) Create(builder *Builder) error {
 	if err != nil {
 		return err
 	}
+	
+	w.SetScrollbars(te.HScroll, te.VScroll)
 
 	return builder.InitWidget(te, w, func() error {
 		if te.AssignTo != nil {

--- a/textedit.go
+++ b/textedit.go
@@ -19,16 +19,18 @@ type TextEdit struct {
 	WidgetBase
 	readOnlyChangedPublisher EventPublisher
 	textChangedPublisher     EventPublisher
+	horizontal               bool
+	vertical                 bool
 }
 
 func NewTextEdit(parent Container) (*TextEdit, error) {
-	te := new(TextEdit)
+	te := &TextEdit{vertical: true}
 
 	if err := InitWidget(
 		te,
 		parent,
 		"EDIT",
-		win.WS_TABSTOP|win.WS_VISIBLE|win.WS_VSCROLL|win.ES_MULTILINE|win.ES_WANTRETURN,
+		win.WS_TABSTOP|win.WS_VISIBLE|win.ES_MULTILINE|win.ES_WANTRETURN,
 		win.WS_EX_CLIENTEDGE); err != nil {
 		return nil, err
 	}
@@ -121,6 +123,14 @@ func (te *TextEdit) SetReadOnly(readOnly bool) error {
 	te.readOnlyChangedPublisher.Publish()
 
 	return nil
+}
+
+func (te *TextEdit) SetScrollbars(horizontal, vertical bool) {
+	te.horizontal = horizontal
+	te.vertical = vertical
+
+	te.ensureStyleBits(win.WS_HSCROLL, horizontal)
+	te.ensureStyleBits(win.WS_VSCROLL, vertical)
 }
 
 func (te *TextEdit) TextChanged() *Event {


### PR DESCRIPTION
A horizontal scrollbar can now be added to TextEdit like so:

`TextEdit{
	HScroll: true,
	VScroll: true,
},`

Be aware however that the default behaviour has changed if the VScroll and HScroll properties aren't set as no vertical scrollbar will be included in that case. Before this change a vertical scrollbar always existed for TextEdits (and couldn't be disabled).