### PR TITLE
Add ShowReadOnlyCB boolean flag to walk.FileDialog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Attila Tajti <attila.tajti@gmail.com>
 Benny Siegert <bsiegert@gmail.com>
 Cary Cherng <ccherng@gmail.com>
 Hill <zhu.bicen@gmail.com>
+James Scholes <james@jamesscholes.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 ktye <ktye.users.noreply.github.com>
 llxwj <llxwjlove@gmail.com>

--- a/commondialogs.go
+++ b/commondialogs.go
@@ -24,6 +24,7 @@ type FileDialog struct {
 	InitialDirPath string
 	Filter         string
 	FilterIndex    int
+	ShowReadOnlyCB bool
 }
 
 func (dlg *FileDialog) show(owner Form, fun func(ofn *win.OPENFILENAME) bool, flags uint32) (accepted bool, err error) {
@@ -48,6 +49,10 @@ func (dlg *FileDialog) show(owner Form, fun func(ofn *win.OPENFILENAME) bool, fl
 	ofn.LpstrInitialDir = syscall.StringToUTF16Ptr(dlg.InitialDirPath)
 	ofn.LpstrTitle = syscall.StringToUTF16Ptr(dlg.Title)
 	ofn.Flags = win.OFN_FILEMUSTEXIST | flags
+
+	if !dlg.ShowReadOnlyCB {
+		ofn.Flags |= win.OFN_HIDEREADONLY
+	}
 
 	var fileBuf []uint16
 	if flags&win.OFN_ALLOWMULTISELECT > 0 {


### PR DESCRIPTION
Currently, Walk provides no way to determine whether the user checked the read-only mode check box in open file dialogs or not, so it doesn't make much sense to show it by default.  This PR adds the ShowReadOnlyCB boolean flag to walk.FileDialog, which is false when initialised, and can be explicitly set to true if a developer really wants the box to be shown.  Maybe we should also add a way to retrieve the checked state after the user has chosen a file, but that isn't in the scope of my use case for today.

This is my first ever PR so let me know if I'm missing something :)