### PR TITLE
add walk.NewBitmapFromIcon

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 # ============
 
 Alexander Neumann <an2048@gmail.com>
+Aman Gupta <aman@tmm1.net>
 Anthony Dong <adongy@users.noreply.github.com>
 Attila Tajti <attila.tajti@gmail.com>
 Benny Siegert <bsiegert@gmail.com>


### PR DESCRIPTION
This creates a transparent bitmap from an icon

Useful, for example, to take the `IDI_SHIELD` icon and create a bitmap to use with `(*Action).SetImage()`