### PR TITLE
CommandStateChange event is splitted into properties, and other changes

### DIFF
--- a/declarative/webview.go
+++ b/declarative/webview.go
@@ -45,30 +45,32 @@ type WebView struct {
 
 	// WebView
 
-	AssignTo                   **walk.WebView
-	NativeContextMenuEnabled   Property
-	OnBrowserVisibleChanged    walk.EventHandler
-	OnCommandStateChanged      walk.WebViewCommandStateChangedEventHandler
-	OnDocumentCompleted        walk.StringEventHandler
-	OnDocumentTitleChanged     walk.EventHandler
-	OnDownloaded               walk.EventHandler
-	OnDownloading              walk.EventHandler
-	OnNativeContextMenuEnabled walk.EventHandler
-	OnNavigated                walk.StringEventHandler
-	OnNavigatedError           walk.WebViewNavigatedErrorEventHandler
-	OnNavigating               walk.WebViewNavigatingEventHandler
-	OnNewWindow                walk.WebViewNewWindowEventHandler
-	OnProgressChanged          walk.EventHandler
-	OnQuitting                 walk.EventHandler
-	OnShortcutsEnabled         walk.EventHandler
-	OnStatusBarVisibleChanged  walk.EventHandler
-	OnStatusTextChanged        walk.EventHandler
-	OnTheaterModeChanged       walk.EventHandler
-	OnToolBarVisibleChanged    walk.EventHandler
-	OnURLChanged               walk.EventHandler
-	OnWindowClosing            walk.WebViewWindowClosingEventHandler
-	ShortcutsEnabled           Property
-	URL                        Property
+	AssignTo                          **walk.WebView
+	NativeContextMenuEnabled          Property
+	OnBrowserVisibleChanged           walk.EventHandler
+	OnCanGoBackChanged                walk.EventHandler
+	OnCanGoForwardChanged             walk.EventHandler
+	OnDocumentCompleted               walk.StringEventHandler
+	OnDocumentTitleChanged            walk.EventHandler
+	OnDownloaded                      walk.EventHandler
+	OnDownloading                     walk.EventHandler
+	OnNativeContextMenuEnabledChanged walk.EventHandler
+	OnNavigated                       walk.StringEventHandler
+	OnNavigatedError                  walk.WebViewNavigatedErrorEventHandler
+	OnNavigating                      walk.WebViewNavigatingEventHandler
+	OnNewWindow                       walk.WebViewNewWindowEventHandler
+	OnProgressChanged                 walk.EventHandler
+	OnQuitting                        walk.EventHandler
+	OnShortcutsEnabledChanged         walk.EventHandler
+	OnStatusBarVisibleChanged         walk.EventHandler
+	OnStatusTextChanged               walk.EventHandler
+	OnTheaterModeChanged              walk.EventHandler
+	OnToolBarEnabledChanged           walk.EventHandler
+	OnToolBarVisibleChanged           walk.EventHandler
+	OnURLChanged                      walk.EventHandler
+	OnWindowClosing                   walk.WebViewWindowClosingEventHandler
+	ShortcutsEnabled                  Property
+	URL                               Property
 }
 
 func (wv WebView) Create(builder *Builder) error {
@@ -85,8 +87,11 @@ func (wv WebView) Create(builder *Builder) error {
 		if wv.OnBrowserVisibleChanged != nil {
 			w.BrowserVisibleChanged().Attach(wv.OnBrowserVisibleChanged)
 		}
-		if wv.OnCommandStateChanged != nil {
-			w.CommandStateChanged().Attach(wv.OnCommandStateChanged)
+		if wv.OnCanGoBackChanged != nil {
+			w.CanGoBackChanged().Attach(wv.OnCanGoBackChanged)
+		}
+		if wv.OnCanGoForwardChanged != nil {
+			w.CanGoForwardChanged().Attach(wv.OnCanGoForwardChanged)
 		}
 		if wv.OnDocumentCompleted != nil {
 			w.DocumentCompleted().Attach(wv.OnDocumentCompleted)
@@ -100,8 +105,8 @@ func (wv WebView) Create(builder *Builder) error {
 		if wv.OnDownloading != nil {
 			w.Downloading().Attach(wv.OnDownloading)
 		}
-		if wv.OnNativeContextMenuEnabled != nil {
-			w.NativeContextMenuEnabledChanged().Attach(wv.OnNativeContextMenuEnabled)
+		if wv.OnNativeContextMenuEnabledChanged != nil {
+			w.NativeContextMenuEnabledChanged().Attach(wv.OnNativeContextMenuEnabledChanged)
 		}
 		if wv.OnNavigated != nil {
 			w.Navigated().Attach(wv.OnNavigated)
@@ -121,8 +126,8 @@ func (wv WebView) Create(builder *Builder) error {
 		if wv.OnURLChanged != nil {
 			w.URLChanged().Attach(wv.OnURLChanged)
 		}
-		if wv.OnShortcutsEnabled != nil {
-			w.ShortcutsEnabledChanged().Attach(wv.OnShortcutsEnabled)
+		if wv.OnShortcutsEnabledChanged != nil {
+			w.ShortcutsEnabledChanged().Attach(wv.OnShortcutsEnabledChanged)
 		}
 		if wv.OnStatusBarVisibleChanged != nil {
 			w.StatusBarVisibleChanged().Attach(wv.OnStatusBarVisibleChanged)
@@ -132,6 +137,9 @@ func (wv WebView) Create(builder *Builder) error {
 		}
 		if wv.OnTheaterModeChanged != nil {
 			w.TheaterModeChanged().Attach(wv.OnTheaterModeChanged)
+		}
+		if wv.OnToolBarEnabledChanged != nil {
+			w.ToolBarEnabledChanged().Attach(wv.OnToolBarEnabledChanged)
 		}
 		if wv.OnToolBarVisibleChanged != nil {
 			w.ToolBarVisibleChanged().Attach(wv.OnToolBarVisibleChanged)

--- a/examples/webview_events/webview_events.go
+++ b/examples/webview_events/webview_events.go
@@ -66,7 +66,9 @@ func NewMainWin() (*MainWin, error) {
 				OnTheaterModeChanged:      mainWin.webView_OnTheaterModeChanged,
 				OnToolBarVisibleChanged:   mainWin.webView_OnToolBarVisibleChanged,
 				OnBrowserVisibleChanged:   mainWin.webView_OnBrowserVisibleChanged,
-				OnCommandStateChanged:     mainWin.webView_OnCommandStateChanged,
+				OnCanGoBackChanged:        mainWin.webView_OnCanGoBackChanged,
+				OnCanGoForwardChanged:     mainWin.webView_OnCanGoForwardChanged,
+				OnToolBarEnabledChanged:   mainWin.webView_OnToolBarEnabledChanged,
 				OnProgressChanged:         mainWin.webView_OnProgressChanged,
 				OnStatusTextChanged:       mainWin.webView_OnStatusTextChanged,
 				OnDocumentTitleChanged:    mainWin.webView_OnDocumentTitleChanged,
@@ -90,6 +92,7 @@ func (mainWin *MainWin) webView_OnNavigating(eventData *walk.WebViewNavigatingEv
 	fmt.Printf("webView_OnNavigating\r\n")
 	fmt.Printf("Url = %+v\r\n", eventData.Url())
 	fmt.Printf("Flags = %+v\r\n", eventData.Flags())
+	fmt.Printf("PostData = %+v\r\n", eventData.PostData())
 	fmt.Printf("Headers = %+v\r\n", eventData.Headers())
 	fmt.Printf("TargetFrameName = %+v\r\n", eventData.TargetFrameName())
 	fmt.Printf("Canceled = %+v\r\n", eventData.Canceled())
@@ -167,10 +170,19 @@ func (mainWin *MainWin) webView_OnBrowserVisibleChanged() {
 	fmt.Printf("BrowserVisible = %+v\r\n", mainWin.wv.BrowserVisible())
 }
 
-func (mainWin *MainWin) webView_OnCommandStateChanged(eventData *walk.WebViewCommandStateChangedEventData) {
-	fmt.Printf("webView_OnCommandStateChanged\r\n")
-	fmt.Printf("Command = %+v\r\n", eventData.Command())
-	fmt.Printf("Enabled = %+v\r\n", eventData.Enabled())
+func (mainWin *MainWin) webView_OnCanGoBackChanged() {
+	fmt.Printf("webView_OnCanGoBackChanged\r\n")
+	fmt.Printf("CanGoBack = %+v\r\n", mainWin.wv.CanGoBack())
+}
+
+func (mainWin *MainWin) webView_OnCanGoForwardChanged() {
+	fmt.Printf("webView_OnCanGoForwardChanged\r\n")
+	fmt.Printf("CanGoForward = %+v\r\n", mainWin.wv.CanGoForward())
+}
+
+func (mainWin *MainWin) webView_OnToolBarEnabledChanged() {
+	fmt.Printf("webView_OnToolBarEnabledChanged\r\n")
+	fmt.Printf("ToolBarEnabled = %+v\r\n", mainWin.wv.ToolBarEnabled())
 }
 
 func (mainWin *MainWin) webView_OnProgressChanged() {

--- a/webview.go
+++ b/webview.go
@@ -31,31 +31,36 @@ type WebView struct {
 	shortcutsEnabledChangedPublisher         EventPublisher
 	nativeContextMenuEnabled                 bool
 	nativeContextMenuEnabledChangedPublisher EventPublisher
-	navigatingEventPublisher                 WebViewNavigatingEventPublisher
-	navigatedEventPublisher                  StringEventPublisher
-	downloadingEventPublisher                EventPublisher
-	downloadedEventPublisher                 EventPublisher
-	documentCompletedEventPublisher          StringEventPublisher
-	navigatedErrorEventPublisher             WebViewNavigatedErrorEventPublisher
-	newWindowEventPublisher                  WebViewNewWindowEventPublisher
-	quittingEventPublisher                   EventPublisher
-	windowClosingEventPublisher              WebViewWindowClosingEventPublisher
+	navigatingPublisher                      WebViewNavigatingEventPublisher
+	navigatedPublisher                       StringEventPublisher
+	downloadingPublisher                     EventPublisher
+	downloadedPublisher                      EventPublisher
+	documentCompletedPublisher               StringEventPublisher
+	navigatedErrorPublisher                  WebViewNavigatedErrorEventPublisher
+	newWindowPublisher                       WebViewNewWindowEventPublisher
+	quittingPublisher                        EventPublisher
+	windowClosingPublisher                   WebViewWindowClosingEventPublisher
 	statusBarVisible                         bool
-	statusBarVisibleChangedEventPublisher    EventPublisher
+	statusBarVisibleChangedPublisher         EventPublisher
 	isTheaterMode                            bool
-	theaterModeChangedEventPublisher         EventPublisher
+	theaterModeChangedPublisher              EventPublisher
 	toolBarVisible                           bool
-	toolBarVisibleChangedEventPublisher      EventPublisher
+	toolBarVisibleChangedPublisher           EventPublisher
 	browserVisible                           bool
-	browserVisibleChangedEventPublisher      EventPublisher
-	commandStateChangedEventPublisher        WebViewCommandStateChangedEventPublisher
+	browserVisibleChangedPublisher           EventPublisher
+	toolBarEnabled                           bool
+	toolBarEnabledChangedPublisher           EventPublisher
+	canGoBack                                bool
+	canGoBackChangedPublisher                EventPublisher
+	canGoForward                             bool
+	canGoForwardChangedPublisher             EventPublisher
 	progressValue                            int32
 	progressMax                              int32
-	progressChangedEventPublisher            EventPublisher
+	progressChangedPublisher                 EventPublisher
 	statusText                               string
-	statusTextChangedEventPublisher          EventPublisher
+	statusTextChangedPublisher               EventPublisher
 	documentTitle                            string
-	documentTitleChangedEventPublisher       EventPublisher
+	documentTitleChangedPublisher            EventPublisher
 }
 
 func NewWebView(parent Container) (*WebView, error) {
@@ -283,39 +288,39 @@ func (wv *WebView) NativeContextMenuEnabledChanged() *Event {
 }
 
 func (wv *WebView) Navigating() *WebViewNavigatingEvent {
-	return wv.navigatingEventPublisher.Event()
+	return wv.navigatingPublisher.Event()
 }
 
 func (wv *WebView) Navigated() *StringEvent {
-	return wv.navigatedEventPublisher.Event()
+	return wv.navigatedPublisher.Event()
 }
 
 func (wv *WebView) Downloading() *Event {
-	return wv.downloadingEventPublisher.Event()
+	return wv.downloadingPublisher.Event()
 }
 
 func (wv *WebView) Downloaded() *Event {
-	return wv.downloadedEventPublisher.Event()
+	return wv.downloadedPublisher.Event()
 }
 
 func (wv *WebView) DocumentCompleted() *StringEvent {
-	return wv.documentCompletedEventPublisher.Event()
+	return wv.documentCompletedPublisher.Event()
 }
 
 func (wv *WebView) NavigatedError() *WebViewNavigatedErrorEvent {
-	return wv.navigatedErrorEventPublisher.Event()
+	return wv.navigatedErrorPublisher.Event()
 }
 
 func (wv *WebView) NewWindow() *WebViewNewWindowEvent {
-	return wv.newWindowEventPublisher.Event()
+	return wv.newWindowPublisher.Event()
 }
 
 func (wv *WebView) Quitting() *Event {
-	return wv.quittingEventPublisher.Event()
+	return wv.quittingPublisher.Event()
 }
 
 func (wv *WebView) WindowClosing() *WebViewWindowClosingEvent {
-	return wv.windowClosingEventPublisher.Event()
+	return wv.windowClosingPublisher.Event()
 }
 
 func (wv *WebView) StatusBarVisible() bool {
@@ -323,7 +328,7 @@ func (wv *WebView) StatusBarVisible() bool {
 }
 
 func (wv *WebView) StatusBarVisibleChanged() *Event {
-	return wv.statusBarVisibleChangedEventPublisher.Event()
+	return wv.statusBarVisibleChangedPublisher.Event()
 }
 
 func (wv *WebView) IsTheaterMode() bool {
@@ -331,7 +336,7 @@ func (wv *WebView) IsTheaterMode() bool {
 }
 
 func (wv *WebView) TheaterModeChanged() *Event {
-	return wv.theaterModeChangedEventPublisher.Event()
+	return wv.theaterModeChangedPublisher.Event()
 }
 
 func (wv *WebView) ToolBarVisible() bool {
@@ -339,7 +344,7 @@ func (wv *WebView) ToolBarVisible() bool {
 }
 
 func (wv *WebView) ToolBarVisibleChanged() *Event {
-	return wv.toolBarVisibleChangedEventPublisher.Event()
+	return wv.toolBarVisibleChangedPublisher.Event()
 }
 
 func (wv *WebView) BrowserVisible() bool {
@@ -347,11 +352,31 @@ func (wv *WebView) BrowserVisible() bool {
 }
 
 func (wv *WebView) BrowserVisibleChanged() *Event {
-	return wv.browserVisibleChangedEventPublisher.Event()
+	return wv.browserVisibleChangedPublisher.Event()
 }
 
-func (wv *WebView) CommandStateChanged() *WebViewCommandStateChangedEvent {
-	return wv.commandStateChangedEventPublisher.Event()
+func (wv *WebView) ToolBarEnabled() bool {
+	return wv.toolBarEnabled
+}
+
+func (wv *WebView) ToolBarEnabledChanged() *Event {
+	return wv.toolBarEnabledChangedPublisher.Event()
+}
+
+func (wv *WebView) CanGoBack() bool {
+	return wv.canGoBack
+}
+
+func (wv *WebView) CanGoBackChanged() *Event {
+	return wv.canGoBackChangedPublisher.Event()
+}
+
+func (wv *WebView) CanGoForward() bool {
+	return wv.canGoForward
+}
+
+func (wv *WebView) CanGoForwardChanged() *Event {
+	return wv.canGoForwardChangedPublisher.Event()
 }
 
 func (wv *WebView) ProgressValue() int32 {
@@ -363,7 +388,7 @@ func (wv *WebView) ProgressMax() int32 {
 }
 
 func (wv *WebView) ProgressChanged() *Event {
-	return wv.progressChangedEventPublisher.Event()
+	return wv.progressChangedPublisher.Event()
 }
 
 func (wv *WebView) StatusText() string {
@@ -371,7 +396,7 @@ func (wv *WebView) StatusText() string {
 }
 
 func (wv *WebView) StatusTextChanged() *Event {
-	return wv.statusTextChangedEventPublisher.Event()
+	return wv.statusTextChangedPublisher.Event()
 }
 
 func (wv *WebView) DocumentTitle() string {
@@ -379,7 +404,7 @@ func (wv *WebView) DocumentTitle() string {
 }
 
 func (wv *WebView) DocumentTitleChanged() *Event {
-	return wv.documentTitleChangedEventPublisher.Event()
+	return wv.documentTitleChangedPublisher.Event()
 }
 
 func (wv *WebView) Refresh() error {

--- a/webview_dwebbrowserevents2.go
+++ b/webview_dwebbrowserevents2.go
@@ -150,7 +150,7 @@ func webView_DWebBrowserEvents2_Invoke(
 			headers:         (*rgvargPtr)[1].MustPVariant(),
 			cancel:          (*rgvargPtr)[0].MustPBool(),
 		}
-		wv.navigatingEventPublisher.Publish(eventData)
+		wv.navigatingPublisher.Publish(eventData)
 
 	case win.DISPID_NAVIGATECOMPLETE2:
 		rgvargPtr := (*[2]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -159,15 +159,15 @@ func webView_DWebBrowserEvents2_Invoke(
 		if url != nil && url.MustBSTR() != nil {
 			urlStr = win.BSTRToString(url.MustBSTR())
 		}
-		wv.navigatedEventPublisher.Publish(urlStr)
+		wv.navigatedPublisher.Publish(urlStr)
 
 		wv.urlChangedPublisher.Publish()
 
 	case win.DISPID_DOWNLOADBEGIN:
-		wv.downloadingEventPublisher.Publish()
+		wv.downloadingPublisher.Publish()
 
 	case win.DISPID_DOWNLOADCOMPLETE:
-		wv.downloadedEventPublisher.Publish()
+		wv.downloadedPublisher.Publish()
 
 	case win.DISPID_DOCUMENTCOMPLETE:
 		rgvargPtr := (*[2]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -188,7 +188,7 @@ func webView_DWebBrowserEvents2_Invoke(
 			})
 		})
 
-		wv.documentCompletedEventPublisher.Publish(urlStr)
+		wv.documentCompletedPublisher.Publish(urlStr)
 
 	case win.DISPID_NAVIGATEERROR:
 		rgvargPtr := (*[5]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -199,7 +199,7 @@ func webView_DWebBrowserEvents2_Invoke(
 			statusCode:      (*rgvargPtr)[1].MustPVariant(),
 			cancel:          (*rgvargPtr)[0].MustPBool(),
 		}
-		wv.navigatedErrorEventPublisher.Publish(eventData)
+		wv.navigatedErrorPublisher.Publish(eventData)
 
 	case win.DISPID_NEWWINDOW3:
 		rgvargPtr := (*[5]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -210,10 +210,10 @@ func webView_DWebBrowserEvents2_Invoke(
 			bstrUrlContext: (*rgvargPtr)[1].MustBSTR(),
 			bstrUrl:        (*rgvargPtr)[0].MustBSTR(),
 		}
-		wv.newWindowEventPublisher.Publish(eventData)
+		wv.newWindowPublisher.Publish(eventData)
 
 	case win.DISPID_ONQUIT:
-		wv.quittingEventPublisher.Publish()
+		wv.quittingPublisher.Publish()
 
 	case win.DISPID_WINDOWCLOSING:
 		rgvargPtr := (*[2]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -221,7 +221,7 @@ func webView_DWebBrowserEvents2_Invoke(
 			bIsChildWindow: (*rgvargPtr)[1].MustBool(),
 			cancel:         (*rgvargPtr)[0].MustPBool(),
 		}
-		wv.windowClosingEventPublisher.Publish(eventData)
+		wv.windowClosingPublisher.Publish(eventData)
 
 	case win.DISPID_ONSTATUSBAR:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -231,7 +231,7 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.statusBarVisible = false
 		}
-		wv.statusBarVisibleChangedEventPublisher.Publish()
+		wv.statusBarVisibleChangedPublisher.Publish()
 
 	case win.DISPID_ONTHEATERMODE:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -241,7 +241,7 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.isTheaterMode = false
 		}
-		wv.theaterModeChangedEventPublisher.Publish()
+		wv.theaterModeChangedPublisher.Publish()
 
 	case win.DISPID_ONTOOLBAR:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -251,7 +251,7 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.toolBarVisible = false
 		}
-		wv.toolBarVisibleChangedEventPublisher.Publish()
+		wv.toolBarVisibleChangedPublisher.Publish()
 
 	case win.DISPID_ONVISIBLE:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -261,21 +261,32 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.browserVisible = false
 		}
-		wv.browserVisibleChangedEventPublisher.Publish()
+		wv.browserVisibleChangedPublisher.Publish()
 
 	case win.DISPID_COMMANDSTATECHANGE:
 		rgvargPtr := (*[2]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
-		eventData := &WebViewCommandStateChangedEventData{
-			command: (*rgvargPtr)[1].MustLong(),
-			enable:  (*rgvargPtr)[0].MustBool(),
+		command := (*rgvargPtr)[1].MustLong()
+		enable := (*rgvargPtr)[0].MustBool()
+		enableBool := (enable != win.VARIANT_FALSE)
+		switch command {
+		case win.CSC_UPDATECOMMANDS:
+			wv.toolBarEnabled = enableBool
+			wv.toolBarEnabledChangedPublisher.Publish()
+
+		case win.CSC_NAVIGATEFORWARD:
+			wv.canGoForward = enableBool
+			wv.canGoForwardChangedPublisher.Publish()
+
+		case win.CSC_NAVIGATEBACK:
+			wv.canGoBack = enableBool
+			wv.canGoBackChangedPublisher.Publish()
 		}
-		wv.commandStateChangedEventPublisher.Publish(eventData)
 
 	case win.DISPID_PROGRESSCHANGE:
 		rgvargPtr := (*[2]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
 		wv.progressValue = (*rgvargPtr)[1].MustLong()
 		wv.progressMax = (*rgvargPtr)[0].MustLong()
-		wv.progressChangedEventPublisher.Publish()
+		wv.progressChangedPublisher.Publish()
 
 	case win.DISPID_STATUSTEXTCHANGE:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -285,7 +296,7 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.statusText = ""
 		}
-		wv.statusTextChangedEventPublisher.Publish()
+		wv.statusTextChangedPublisher.Publish()
 
 	case win.DISPID_TITLECHANGE:
 		rgvargPtr := (*[1]win.VARIANTARG)(unsafe.Pointer(pDispParams.Rgvarg))
@@ -295,7 +306,7 @@ func webView_DWebBrowserEvents2_Invoke(
 		} else {
 			wv.documentTitle = ""
 		}
-		wv.documentTitleChangedEventPublisher.Publish()
+		wv.documentTitleChangedPublisher.Publish()
 	}
 
 	return win.DISP_E_MEMBERNOTFOUND


### PR DESCRIPTION
(1)CommandStateChange event of DWebBrowser2.Invoke is splitted into 3 properties: ToolBarEnabled, CanGoBack, CanGoForward , preventing the use of constants in lxn/win package.
(2)WebViewNavigatingEventData.PostData is added
(3)fooEventPublisher is renamed to fooPublisher.
Thank you.
