### PR TITLE
add NewTabWidgetWithStyle()

### DIFF
--- a/tabwidget.go
+++ b/tabwidget.go
@@ -34,6 +34,10 @@ type TabWidget struct {
 }
 
 func NewTabWidget(parent Container) (*TabWidget, error) {
+	return NewTabWidgetWithStyle(parent, 0)
+}
+
+func NewTabWidgetWithStyle(parent Container, style uint32) (*TabWidget, error) {
 	tw := &TabWidget{currentIndex: -1}
 	tw.pages = newTabPageList(tw)
 
@@ -57,7 +61,7 @@ func NewTabWidget(parent Container) (*TabWidget, error) {
 
 	tw.hWndTab = win.CreateWindowEx(
 		0, syscall.StringToUTF16Ptr("SysTabControl32"), nil,
-		win.WS_CHILD|win.WS_CLIPSIBLINGS|win.WS_TABSTOP|win.WS_VISIBLE,
+		win.WS_CHILD|win.WS_CLIPSIBLINGS|win.WS_TABSTOP|win.WS_VISIBLE|style,
 		0, 0, 0, 0, tw.hWnd, 0, 0, nil)
 	if tw.hWndTab == 0 {
 		return nil, lastError("CreateWindowEx")


### PR DESCRIPTION
 - enables a user to apply these styles to a tab widget:
   https://docs.microsoft.com/en-us/windows/desktop/Controls/tab-control-styles

 - follows the convention of other functions in this package
   like NewCompositeWithStyle and NewListBoxWithStyle

```
tabWidget, err := walk.NewTabWidgetWithStyle(mw, win.TCS_MULTILINE)
checkErr(err)
mw.Children().Add(tabWidget)
```

![multilinetabs](https://user-images.githubusercontent.com/8731605/42945908-9f713328-8b37-11e8-97ec-0ae73e1c7e3c.png)

