### PR TITLE
Allow simple font derivatives like Font{Bold:true}

### DIFF
--- a/declarative/font.go
+++ b/declarative/font.go
@@ -20,10 +20,6 @@ type Font struct {
 }
 
 func (f Font) Create() (*walk.Font, error) {
-	if f.Family == "" && f.PointSize == 0 {
-		return nil, nil
-	}
-
 	var fs walk.FontStyle
 
 	if f.Bold {

--- a/font.go
+++ b/font.go
@@ -66,6 +66,13 @@ func NewFont(family string, pointSize int, style FontStyle) (*Font, error) {
 		return nil, newError("invalid style")
 	}
 
+	if family == "" {
+		family = defaultFont.family
+	}
+	if pointSize == 0 {
+		pointSize = defaultFont.pointSize
+	}
+
 	fi := fontInfo{
 		family:    family,
 		pointSize: pointSize,

--- a/font.go
+++ b/font.go
@@ -66,13 +66,6 @@ func NewFont(family string, pointSize int, style FontStyle) (*Font, error) {
 		return nil, newError("invalid style")
 	}
 
-	if family == "" {
-		family = defaultFont.family
-	}
-	if pointSize == 0 {
-		pointSize = defaultFont.pointSize
-	}
-
 	fi := fontInfo{
 		family:    family,
 		pointSize: pointSize,
@@ -88,6 +81,10 @@ func NewFont(family string, pointSize int, style FontStyle) (*Font, error) {
 		pointSize: pointSize,
 		style:     style,
 		dpi2hFont: make(map[int]win.HFONT),
+	}
+
+	if family == "" || pointSize == 0 {
+		return font, nil
 	}
 
 	knownFonts[fi] = font

--- a/window.go
+++ b/window.go
@@ -809,6 +809,24 @@ func (wb *WindowBase) Font() *Font {
 
 // SetFont sets the *Font of the *WindowBase.
 func (wb *WindowBase) SetFont(font *Font) {
+	if font.family == "" || font.pointSize == 0 {
+		var parentFont *Font
+
+		if widget, ok := wb.window.(Widget); ok {
+			widgetBase :=widget.AsWidgetBase()
+			if widget.AsWidgetBase().parent != nil {
+				parentFont = widgetBase.parent.Font()
+			}
+		}
+
+		if font.family == "" && parentFont != nil {
+			font.family = parentFont.family
+		}
+		if font.pointSize == 0 && parentFont != nil {
+			font.pointSize = parentFont.pointSize
+		}
+	}
+
 	if font != wb.font {
 		wb.font = font
 


### PR DESCRIPTION
I found that passing a Font without name or point size didn't apply as the method returned.
Instead it should use the default font and size so we can derive a bold or italic font from default...