### PR TITLE
Create manifest file programmatically

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Semyon Tokarev <zlobzn@gmail.com>
 Shawn Sun <datago@yeah.net>
 Tim Dufrane <tim.dufrane@gmail.com>
 Vincent Vanackere <vincent.vanackere@gmail.com>
+gonutz

--- a/README.mdown
+++ b/README.mdown
@@ -59,32 +59,6 @@ func main() {
 }
 ```
 
-##### Create Manifest `test.manifest`
-
-```xml
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="SomeFunkyNameHere" type="win32"/>
-    <dependency>
-        <dependentAssembly>
-            <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
-        </dependentAssembly>
-    </dependency>
-    <asmv3:application>
-        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-            <dpiAware>true</dpiAware>
-        </asmv3:windowsSettings>
-    </asmv3:application>
-</assembly>
-```
-
-Then either compile the manifest using the [rsrc tool](https://github.com/akavel/rsrc), like this:
-
-	go get github.com/akavel/rsrc
-	rsrc -manifest test.manifest -o rsrc.syso
-
-or rename the `test.manifest` file to `test.exe.manifest` and distribute it with the application instead.
-
 ##### Build app
 
 In the directory containing `test.go` run
@@ -105,22 +79,6 @@ To get rid of the cmd window, instead run
 
 ##### More Examples
 There are some [examples](examples) that should get you started.
-
-Application Manifest Files
-==========================
-Walk requires Common Controls 6. This means that you must put an appropriate
-application manifest file either next to your executable or embedded as a
-resource.
-
-You can copy one of the application manifest files that come with the examples.
-
-To embed a manifest file as a resource, you can use the [rsrc tool](https://github.com/akavel/rsrc).
-
-IMPORTANT: If you don't embed a manifest as a resource, then you should not launch
-your executable before the manifest file is in place.
-If you do anyway, the program will not run properly. And worse, Windows will not
-recognize a manifest file, you later drop next to the executable. To fix this,
-rebuild your executable and only launch it with a manifest file in place.
 
 Program Crashes
 ===============

--- a/manifest.go
+++ b/manifest.go
@@ -1,3 +1,9 @@
+// Copyright 2018 The Walk Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
 package walk
 
 import (

--- a/manifest.go
+++ b/manifest.go
@@ -1,0 +1,49 @@
+package walk
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/lxn/win"
+)
+
+/*
+This function creates a manifest file for this application and activates it
+before creating the GUI controls. This way, the common controls version 6 is
+used automatically and the users of this library does not need to mess with
+manifest files themselves.
+*/
+func init() {
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	manifest := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="` + appName + `" type="win32"/>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+        </dependentAssembly>
+    </dependency>
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+            <dpiAware>true</dpiAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>`
+	// create a temporary manifest file, load it, then delete it
+	f, err := ioutil.TempFile("", "manifest_")
+	if err != nil {
+		return
+	}
+	manifestPath := f.Name()
+	defer os.Remove(manifestPath)
+	f.WriteString(manifest)
+	f.Close()
+	ctx := win.CreateActCtx(&win.ACTCTX{
+		Source: syscall.StringToUTF16Ptr(manifestPath),
+	})
+	win.ActivateActCtx(ctx)
+}


### PR DESCRIPTION
This removes the hassle for the user to mess with manifest files.

We also have control over the exact contents of the manifest file, no user errors.

I had to learn about these manifest files in order to get my program working and I think as a GUI library we should make it as easy on the user as possible to get their code up and running. Creating a manifest file on behalf of the user will save them the trouble of having to learn about them and it makes simple Go files go runnable.