### PR TITLE
Fix examples `Size`

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -39,7 +39,7 @@ func main() {
 
 	MainWindow{
 		Title:   "SCREAMO",
-		MinSize: Size{600, 400},
+		Size: Size{600, 400},
 		Layout:  VBox{},
 		Children: []Widget{
 			HSplitter{

--- a/examples/actions/actions.go
+++ b/examples/actions/actions.go
@@ -121,6 +121,7 @@ func main() {
 			ActionRef{&showAboutBoxAction},
 		},
 		MinSize: Size{300, 200},
+		Size:    Size{300, 200},
 		Layout:  VBox{},
 		Children: []Widget{
 			CheckBox{

--- a/examples/clipboard/clipboard.go
+++ b/examples/clipboard/clipboard.go
@@ -19,6 +19,7 @@ func main() {
 	if _, err := (MainWindow{
 		Title:   "Walk Clipboard Example",
 		MinSize: Size{300, 200},
+		Size:    Size{300, 200},
 		Layout:  VBox{},
 		Children: []Widget{
 			PushButton{

--- a/examples/databinding/databinding.go
+++ b/examples/databinding/databinding.go
@@ -29,6 +29,7 @@ func main() {
 		AssignTo: &mw,
 		Title:    "Walk Data Binding Example",
 		MinSize:  Size{300, 200},
+		Size:     Size{300, 200},
 		Layout:   VBox{},
 		Children: []Widget{
 			PushButton{

--- a/examples/dropfiles/dropfiles.go
+++ b/examples/dropfiles/dropfiles.go
@@ -16,6 +16,7 @@ func main() {
 	MainWindow{
 		Title:   "Walk DropFiles Example",
 		MinSize: Size{320, 240},
+		Size:    Size{320, 240},
 		Layout:  VBox{},
 		OnDropFiles: func(files []string) {
 			textEdit.SetText(strings.Join(files, "\r\n"))

--- a/examples/gradientcomposite/gradientcomposite.go
+++ b/examples/gradientcomposite/gradientcomposite.go
@@ -13,6 +13,7 @@ func main() {
 	MainWindow{
 		Title:   "Walk GradientComposite Example",
 		MinSize: Size{400, 0},
+		Size:    Size{400, 0},
 		Background: GradientBrush{
 			Vertexes: []walk.GradientVertex{
 				{X: 0, Y: 0, Color: walk.RGB(255, 255, 127)},

--- a/examples/imageicon/main.go
+++ b/examples/imageicon/main.go
@@ -24,6 +24,7 @@ func main() {
 	if _, err := (MainWindow{
 		AssignTo: &mw,
 		Title:    "Walk Image Icon Example",
+		Size:     Size{320, 240},
 		Layout:   HBox{},
 		Children: []Widget{
 			HSpacer{},

--- a/examples/linklabel/linklabel.go
+++ b/examples/linklabel/linklabel.go
@@ -17,6 +17,7 @@ func main() {
 	if _, err := (MainWindow{
 		Title:   "Walk LinkLabel Example",
 		MinSize: Size{300, 200},
+		Size:    Size{300, 200},
 		Layout:  VBox{},
 		Children: []Widget{
 			LinkLabel{

--- a/examples/radiobutton/radiobutton.go
+++ b/examples/radiobutton/radiobutton.go
@@ -23,6 +23,7 @@ func main() {
 	MainWindow{
 		Title:   "Walk RadioButton Example",
 		MinSize: Size{320, 240},
+		Size:    Size{320, 240},
 		Layout:  VBox{},
 		DataBinder: DataBinder{
 			DataSource: foo,

--- a/examples/settings/settings.go
+++ b/examples/settings/settings.go
@@ -50,10 +50,11 @@ func RunMainWindow() error {
 		Name:    "mainWindow", // Name is needed for settings persistence
 		Title:   "Walk Settings Example",
 		MinSize: Size{800, 600},
+		Size:    Size{800, 600},
 		Layout:  VBox{MarginsZero: true},
 		Children: []Widget{
 			TableView{
-				Name: "tableView", // Name is needed for settings persistence
+				Name:                  "tableView", // Name is needed for settings persistence
 				AlternatingRowBGColor: walk.RGB(255, 255, 200),
 				ColumnsOrderable:      true,
 				Columns: []TableViewColumn{

--- a/examples/slider/slider.go
+++ b/examples/slider/slider.go
@@ -20,6 +20,7 @@ func main() {
 	MainWindow{
 		Title:   "Walk Slider Example",
 		MinSize: Size{320, 240},
+		Size:    Size{320, 240},
 		Layout:  HBox{},
 		Children: []Widget{
 			Slider{

--- a/examples/statusbar/statusbar.go
+++ b/examples/statusbar/statusbar.go
@@ -29,6 +29,7 @@ func main() {
 	MainWindow{
 		Title:   "Walk Statusbar Example",
 		MinSize: Size{600, 200},
+		Size:    Size{600, 200},
 		Layout:  VBox{MarginsZero: true},
 		StatusBarItems: []StatusBarItem{
 			StatusBarItem{

--- a/examples/webview/webview.go
+++ b/examples/webview/webview.go
@@ -19,6 +19,7 @@ func main() {
 		Icon:    Bind("'../img/' + icon(wv.URL) + '.ico'"),
 		Title:   "Walk WebView Example'",
 		MinSize: Size{800, 600},
+		Size:    Size{800, 600},
 		Layout:  VBox{MarginsZero: true},
 		Children: []Widget{
 			LineEdit{

--- a/examples/webview_events/webview_events.go
+++ b/examples/webview_events/webview_events.go
@@ -36,6 +36,7 @@ func NewMainWin() (*MainWin, error) {
 		Icon:     Bind("'../img/' + icon(mainWin.wv.URL) + '.ico'"),
 		Title:    "Walk WebView Example (With Events Printing)",
 		MinSize:  Size{800, 600},
+		Size:     Size{800, 600},
 		Layout:   VBox{MarginsZero: true},
 		Children: []Widget{
 			LineEdit{

--- a/label.go
+++ b/label.go
@@ -41,10 +41,6 @@ func (l *Label) asStatic() *static {
 }
 
 func (l *Label) LayoutFlags() LayoutFlags {
-	if l.TextAlignment() == AlignNear {
-		return GrowableVert
-	}
-
 	return GrowableHorz | GrowableVert
 }
 


### PR DESCRIPTION
Hi
I find you've improved a lot in the last two days. When I updated it to my project, I found a problem. The `MainWindow` is smaller. Then I looked at the examples in the project. Some examples are normal and others are smaller, Even include sample programs on the project home page. Now `MinSize` can't set the initial size of the `MainWindow`.

I wrote this through translation software, If there is no clear expression, please forgive me. Because my poor English is really hard to communicate with others.