### PR TITLE
Label: `TextAlignment` set `AlignNear` failed.

### DIFF
--- a/label.go
+++ b/label.go
@@ -41,10 +41,6 @@ func (l *Label) asStatic() *static {
 }
 
 func (l *Label) LayoutFlags() LayoutFlags {
-	if l.TextAlignment() == AlignNear {
-		return GrowableVert
-	}
-
 	return GrowableHorz | GrowableVert
 }
 


### PR DESCRIPTION
Hi
I found a problem in the new version. Then I made this change and it returned to normal. I'm not sure if it fits your plan.

Before:
![default](https://user-images.githubusercontent.com/16683806/49622063-f8738900-fa02-11e8-994e-f454786899fe.png)
After:
![default](https://user-images.githubusercontent.com/16683806/49622082-0aedc280-fa03-11e8-9533-1a088667d296.png)

```golang
package main

import (
	. "github.com/lxn/walk/declarative"
)

func main() {

	MainWindow{
		Title:   "Label Test",
		MinSize: Size{Width: 300, Height: 200},
		Layout:  VBox{},
		Children: []Widget{
			Label{
				Text: "Default",
			},
			Label{
				Text:          "AlignNear",
				TextAlignment: AlignNear,
			},
			Label{
				Text:          "AlignCenter",
				TextAlignment: AlignCenter,
			},
			Label{
				Text:          "AlignFar",
				TextAlignment: AlignFar,
			},
		},
	}.Run()
}

```