### PR TITLE
Add NotEmpty validator for string fields

### DIFF
--- a/declarative/validators.go
+++ b/declarative/validators.go
@@ -42,6 +42,13 @@ func (SelRequired) Create() (walk.Validator, error) {
 	return walk.SelectionRequiredValidator(), nil
 }
 
+type NotEmpty struct {
+}
+
+func (NotEmpty) Create() (walk.Validator, error) {
+	return walk.NotEmptyValidator(), nil
+}
+
 type dMultiValidator struct {
 	validators []Validator
 }

--- a/validators.go
+++ b/validators.go
@@ -150,3 +150,21 @@ func (selectionRequiredValidator) Validate(v interface{}) error {
 
 	return nil
 }
+
+type notEmptyValidator struct {
+}
+
+var notEmptyValidatorSingleton Validator = notEmptyValidator{}
+
+func NotEmptyValidator() Validator {
+	return notEmptyValidatorSingleton
+}
+
+func (notEmptyValidator) Validate(v interface{}) error {
+	if s := v.(string); len(s) <= 0 {
+		return NewValidationError(
+			tr("Empty field", "walk"),
+			tr("Please fill out the required fields.", "walk"))
+	}
+	return nil
+}


### PR DESCRIPTION
Adding a new `Validator` based on `SelRequired{}`. This basically allows you to require that a string field (such as `LineEdit`) in the form contain a non-empty value. The string in considered non-empty as long as its length is greater than `0`.