### PR TITLE
boxlayout: Use same margins and spacing for non-declarative UIs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Benny Siegert <bsiegert@gmail.com>
 Cary Cherng <ccherng@gmail.com>
 Hill <zhu.bicen@gmail.com>
 James Scholes <james@jamesscholes.com>
+Jason A. Donenfeld <Jason@zx2c4.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 ktye <ktye.users.noreply.github.com>
 llxwj <llxwjlove@gmail.com>

--- a/boxlayout.go
+++ b/boxlayout.go
@@ -34,6 +34,8 @@ func newBoxLayout(orientation Orientation) *BoxLayout {
 		orientation:        orientation,
 		hwnd2StretchFactor: make(map[win.HWND]int),
 		size2MinSize:       make(map[Size]Size),
+		margins:            Margins{9, 9, 9, 9},
+		spacing:            6,
 	}
 }
 


### PR DESCRIPTION
Currently folks not using the declarative UI encounter zero margins and
spacing, because only the declarative structure has these nice defaults.
It's probably a good idea to give the real object the nice defaults too.