### PR TITLE
textlabel: Remove double comment layers

### DIFF
--- a/textlabel.go
+++ b/textlabel.go
@@ -1,8 +1,8 @@
-// // Copyright 2018 The Walk Authors. All rights reserved.
-// // Use of this source code is governed by a BSD-style
-// // license that can be found in the LICENSE file.
+// Copyright 2018 The Walk Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
-// // +build windows
+// +build windows
 
 package walk
 


### PR DESCRIPTION
Having // // +build resulted in that tag being ignored entirely.