### PR TITLE
TabPageList: Recalculate layout on addition

### DIFF
--- a/tabpagelist.go
+++ b/tabpagelist.go
@@ -108,6 +108,10 @@ func (l *TabPageList) Insert(index int, item *TabPage) error {
 		}
 	}
 
+	if item.Layout() != nil {
+		item.Layout().Update(false)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This fixes this weird jump:

![updater-layout-jump](https://user-images.githubusercontent.com/10643/57065175-f15a5980-6cc8-11e9-9d4c-0cf92adf755f.gif)
