### PR TITLE
Add FontMemResource type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Semyon Tokarev <zlobzn@gmail.com>
 Shawn Sun <datago@yeah.net>
 Tim Dufrane <tim.dufrane@gmail.com>
 Vincent Vanackere <vincent.vanackere@gmail.com>
+Dmitry Bagdanov <dimbojob@gmail.com>

--- a/fontresource.go
+++ b/fontresource.go
@@ -8,6 +8,7 @@ package walk
 
 import (
 	"github.com/lxn/win"
+	"syscall"
 )
 
 // FontMemResource represents a font resource loaded into memory from 
@@ -16,12 +17,10 @@ type FontMemResource struct {
 	hFontResource win.HANDLE
 }
 
-// NewFontMemResource function loads a font resource from the executable's resources.
-// The font must be embedded into resources using corresponding operator in the 
-// application's RC script.
-func NewFontMemResource(hModule win.HMODULE, resourceName *uint16) (*FontMemResource, error) {
+func newFontMemResource(resourceName *uint16) (*FontMemResource, error) {
+	hModule := win.HMODULE(win.GetModuleHandle(nil))
 	if hModule == win.HMODULE(0) {
-		hModule = win.HMODULE(win.GetModuleHandle(nil))	
+		return nil, lastError("GetModuleHandle")
 	}
 	
 	hres := win.FindResource(hModule, resourceName, win.MAKEINTRESOURCE(8) /*RT_FONT*/)
@@ -52,6 +51,22 @@ func NewFontMemResource(hModule win.HMODULE, resourceName *uint16) (*FontMemReso
 	}
 
 	return &FontMemResource { hFontResource: hFontResource }, nil
+}
+
+// NewFontMemResourceByName function loads a font resource from the executable's resources
+// using the resource name. 
+// The font must be embedded into resources using corresponding operator in the 
+// application's RC script.
+func NewFontMemResourceByName(name string) (*FontMemResource, error) {
+	return newFontMemResource(syscall.StringToUTF16Ptr(name))
+}
+
+// NewFontMemResourceById function loads a font resource from the executable's resources 
+// using the resource ID.
+// The font must be embedded into resources using corresponding operator in the 
+// application's RC script.
+func NewFontMemResourceById(id int) (*FontMemResource, error) {
+	return newFontMemResource(win.MAKEINTRESOURCE(uintptr(id)))
 }
 
 // Dispose removes the font resource from memory

--- a/fontresource.go
+++ b/fontresource.go
@@ -58,7 +58,12 @@ func newFontMemResource(resourceName *uint16) (*FontMemResource, error) {
 // The font must be embedded into resources using corresponding operator in the 
 // application's RC script.
 func NewFontMemResourceByName(name string) (*FontMemResource, error) {
-	return newFontMemResource(syscall.StringToUTF16Ptr(name))
+	lpstr, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return newFontMemResource(lpstr)
 }
 
 // NewFontMemResourceById function loads a font resource from the executable's resources 


### PR DESCRIPTION
Add FontMemResource type which allows to load fonts from the application's resources.
This PR requires corresponding PR https://github.com/lxn/win/pull/67 to be merged into `lxn/win` project.