### PR TITLE
actionlist: provide means of attaching shortcuts to windows

### DIFF
--- a/actionlist.go
+++ b/actionlist.go
@@ -174,3 +174,17 @@ func (l *ActionList) updateSeparatorVisibility() error {
 
 	return nil
 }
+
+func (l *ActionList) AttachShortcuts(w Window) {
+	shortcuts := make(map[Shortcut]*Action, len(l.actions))
+	for _, action := range l.actions {
+		if action.Shortcut().Key != 0 {
+			shortcuts[action.Shortcut()] = action
+		}
+	}
+	w.KeyDown().Attach(func(key Key) {
+		if action, ok := shortcuts[Shortcut{ModifiersDown(), key}]; ok {
+			action.raiseTriggered()
+		}
+	})
+}


### PR DESCRIPTION
Prior, only shortcuts for main menus worked. With this, it's possible to
attach context menu shortcuts or toolbar shortcuts to arbitrary window
objects.

This isn't super elegant -- it'd be nice were this done automatically.
But even in the automatic case, it's possible that folks might want to
attach shortcuts to additional windows beyond the one that has the
toolbar or context menu.