### PR TITLE
notifyicon: remove balloon icon hack

### DIFF
--- a/notifyicon.go
+++ b/notifyicon.go
@@ -163,15 +163,8 @@ func (ni *NotifyIcon) showMessage(title, info string, iconType uint32, icon *Ico
 	nid.DwInfoFlags = iconType
 	var oldIcon *Icon
 	if iconType == win.NIIF_USER && icon != nil {
-		if win.GetVersion()&0xff >= 6 {
-			nid.HBalloonIcon = icon.hIcon
-			if ni.icon != nil {
-				nid.HIcon = ni.icon.hIcon
-			}
-		} else {
-			oldIcon = ni.icon
-			nid.HIcon = icon.hIcon
-		}
+		oldIcon = ni.icon
+		nid.HIcon = icon.hIcon
 		nid.UFlags |= win.NIF_ICON
 	}
 	if title16, err := syscall.UTF16FromString(title); err == nil {


### PR DESCRIPTION
We either need to upgrade the whole state machine to notify icon v4, or
not use this parameter. The trick here works on Windows 10, but not on
Windows 7.