### PR TITLE
tableviewcolumn: do DPI conversion in create() too

### DIFF
--- a/tableviewcolumn.go
+++ b/tableviewcolumn.go
@@ -380,6 +380,7 @@ func (tvc *TableViewColumn) create() error {
 	} else {
 		lvc.Cx = 100
 	}
+	lvc.Cx = int32(tvc.tv.IntFrom96DPI(int(lvc.Cx)))
 
 	switch tvc.alignment {
 	case AlignCenter:


### PR DESCRIPTION
You remembered the update()->getLVCOLUMN() path, but forgot about the create() path, so this fixes that oversight.