### PR TITLE
tabwidget: use DPI-dependent bitmap size

### DIFF
--- a/tabwidget.go
+++ b/tabwidget.go
@@ -664,7 +664,7 @@ func (tw *TabWidget) imageIndex(image *Bitmap) (index int32, err error) {
 	index = -1
 	if image != nil {
 		if tw.imageList == nil {
-			if tw.imageList, err = NewImageList(Size{16, 16}, 0); err != nil {
+			if tw.imageList, err = NewImageList(Size{tw.DPI() / 6, tw.DPI() / 6}, 0); err != nil {
 				return
 			}
 


### PR DESCRIPTION
I assume you'll be getting rid of this once the new fancy DPI icons
stuff lands, but in the meantime, this at least makes the tabwidget work
when the DPI isn't changed at runtime.