### PR TITLE
form: allow taskbarButtonCreatedMsgId through UIPI

### DIFF
--- a/form.go
+++ b/form.go
@@ -157,6 +157,11 @@ func (fb *FormBase) init(form Form) error {
 		},
 		fb.titleChangedPublisher.Event()))
 
+	version := win.GetVersion()
+	if (version & 0xFF) > 6 || ((version & 0xFF) == 6 && (version & 0xFF00 >> 8) > 0) {
+		win.ChangeWindowMessageFilterEx(fb.hWnd, taskbarButtonCreatedMsgId, win.MSGFLT_ALLOW, nil)
+	}
+
 	return nil
 }
 
@@ -726,7 +731,7 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 		major := version & 0xFF
 		minor := version & 0xFF00 >> 8
 		// Check that the OS is Win 7 or later (Win 7 is v6.1).
-		if major > 6 || (major == 6 && minor > 0) {
+		if fb.progressIndicator == nil && (major > 6 || (major == 6 && minor > 0)) {
 			fb.progressIndicator, _ = newTaskbarList3(fb.hWnd)
 		}
 	}


### PR DESCRIPTION
The progress bar doesn't work if we filter taskbarButtonCreatedMsgId.
Since this is crossing a security barrier, only create a new object
once, so that medium integrity processes can't DoS us.

Requires https://github.com/lxn/win/pull/75