### PR TITLE
notifyicon,progressindicator,menu: properly get DPI of enclosing window

### DIFF
--- a/form.go
+++ b/form.go
@@ -736,6 +736,9 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 
 		fb.clientComposite.dpi = dpi
 		fb.ApplyDPI(dpi)
+		if fb.progressIndicator != nil {
+			fb.progressIndicator.SetOverlayIcon(fb.progressIndicator.overlayIcon, fb.progressIndicator.overlayIconDescription)
+		}
 		applyDPIToDescendants(fb.window, dpi)
 
 		rc := (*win.RECT)(unsafe.Pointer(lParam))

--- a/form.go
+++ b/form.go
@@ -739,6 +739,12 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 		if fb.progressIndicator != nil {
 			fb.progressIndicator.SetOverlayIcon(fb.progressIndicator.overlayIcon, fb.progressIndicator.overlayIconDescription)
 		}
+		for ni := range notifyIcons {
+			// We do this on all NotifyIcons, not just ones attached to this form or descendents, because
+			// the notify icon might be on a different screen, and since it can't get notifications itself
+			// we hope that one of the forms did for it.
+			ni.applyDPI()
+		}
 		applyDPIToDescendants(fb.window, dpi)
 
 		rc := (*win.RECT)(unsafe.Pointer(lParam))

--- a/mainwindow.go
+++ b/mainwindow.go
@@ -28,8 +28,6 @@ type MainWindow struct {
 	statusBar       *StatusBar
 }
 
-var mw Form = (*MainWindow)(nil)
-
 func NewMainWindow() (*MainWindow, error) {
 	return NewMainWindowWithName("")
 }

--- a/menu.go
+++ b/menu.go
@@ -19,6 +19,7 @@ type Menu struct {
 	window        Window
 	actions       *ActionList
 	action2bitmap map[*Action]*Bitmap
+	getDPI        func() int
 }
 
 func newMenuBar(window Window) (*Menu, error) {
@@ -110,7 +111,9 @@ func (m *Menu) initMenuItemInfoFromAction(mii *win.MENUITEMINFO, action *Action)
 	if action.image != nil {
 		mii.FMask |= win.MIIM_BITMAP
 		dpi := 96
-		if m.window != nil {
+		if m.getDPI != nil {
+			dpi = m.getDPI()
+		} else if m.window != nil {
 			dpi = m.window.DPI()
 		}
 		if bmp, err := iconCache.Bitmap(action.image, dpi); err == nil {

--- a/menu.go
+++ b/menu.go
@@ -111,9 +111,7 @@ func (m *Menu) initMenuItemInfoFromAction(mii *win.MENUITEMINFO, action *Action)
 		mii.FMask |= win.MIIM_BITMAP
 		dpi := 96
 		if m.window != nil {
-			if mw, ok := m.window.(*MainWindow); ok && mw != nil {
-				dpi = mw.DPI()
-			}
+			dpi = m.window.DPI()
 		}
 		if bmp, err := iconCache.Bitmap(action.image, dpi); err == nil {
 			mii.HbmpItem = bmp.hBmp

--- a/notifyicon.go
+++ b/notifyicon.go
@@ -112,7 +112,7 @@ func NewNotifyIcon(form Form) (*NotifyIcon, error) {
 	if err != nil {
 		return nil, err
 	}
-	menu.window = mw
+	menu.window = form
 
 	ni := &NotifyIcon{
 		id:          nid.UID,

--- a/notifyicon.go
+++ b/notifyicon.go
@@ -112,7 +112,12 @@ func NewNotifyIcon(form Form) (*NotifyIcon, error) {
 	if err != nil {
 		return nil, err
 	}
-	menu.window = form
+	hwnd := win.FindWindow(syscall.StringToUTF16Ptr("Shell_TrayWnd"), syscall.StringToUTF16Ptr(""))
+	if hwnd != 0 {
+		menu.window = &WindowBase{hWnd: hwnd}
+	} else {
+		menu.window = form
+	}
 
 	ni := &NotifyIcon{
 		id:          nid.UID,

--- a/notifyicon.go
+++ b/notifyicon.go
@@ -47,6 +47,16 @@ func notifyIconWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (resul
 			lastError("GetCursorPos")
 		}
 
+		dpi := ni.DPI()
+		if dpi != ni.lastDPI {
+			ni.lastDPI = dpi
+			for _, action := range ni.contextMenu.actions.actions {
+				if action.image != nil {
+					ni.contextMenu.onActionChanged(action)
+				}
+			}
+		}
+
 		actionId := uint16(win.TrackPopupMenuEx(
 			ni.contextMenu.hMenu,
 			win.TPM_NOANIMATION|win.TPM_RETURNCMD,
@@ -72,6 +82,7 @@ func notifyIconWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (resul
 type NotifyIcon struct {
 	id                      uint32
 	hWnd                    win.HWND
+	lastDPI                 int
 	contextMenu             *Menu
 	icon                    Image
 	toolTip                 string

--- a/progressindicator.go
+++ b/progressindicator.go
@@ -16,11 +16,13 @@ import (
 )
 
 type ProgressIndicator struct {
-	hwnd         win.HWND
-	taskbarList3 *win.ITaskbarList3
-	completed    uint32
-	total        uint32
-	state        PIState
+	hwnd                   win.HWND
+	taskbarList3           *win.ITaskbarList3
+	completed              uint32
+	total                  uint32
+	state                  PIState
+	overlayIcon            *Icon
+	overlayIconDescription string
 }
 
 type PIState int
@@ -88,8 +90,14 @@ func (pi *ProgressIndicator) SetOverlayIcon(icon *Icon, description string) erro
 	if icon != nil {
 		handle = icon.handleForDPI(int(win.GetDpiForWindow(pi.hwnd)))
 	}
-	if hr := pi.taskbarList3.SetOverlayIcon(pi.hwnd, handle, syscall.StringToUTF16Ptr(description)); win.FAILED(hr) {
+	description16, err := syscall.UTF16PtrFromString(description)
+	if err != nil {
+		description16 = &[]uint16{0}[0]
+	}
+	if hr := pi.taskbarList3.SetOverlayIcon(pi.hwnd, handle, description16); win.FAILED(hr) {
 		return errorFromHRESULT("ITaskbarList3.SetOverlayIcon", hr)
 	}
+	pi.overlayIcon = icon
+	pi.overlayIconDescription = description
 	return nil
 }


### PR DESCRIPTION
This PR builds up a few commits that do different things. One important thing to note about the notifier window is that we importantly do not assume that FindWindow will always return the same window, as the desktop environment changes overtime. We also can't get notifyicon DPI updates, so we hope that *one* of the forms did for it.