### PR TITLE
messagebox: convert NUL to � to prevent crash

### DIFF
--- a/messagebox.go
+++ b/messagebox.go
@@ -7,6 +7,7 @@
 package walk
 
 import (
+	"strings"
 	"syscall"
 )
 
@@ -58,7 +59,7 @@ func MsgBox(owner Form, title, message string, style MsgBoxStyle) int {
 
 	return int(win.MessageBox(
 		ownerHWnd,
-		syscall.StringToUTF16Ptr(message),
-		syscall.StringToUTF16Ptr(title),
+		syscall.StringToUTF16Ptr(strings.ReplaceAll(message, "\0", "�")),
+		syscall.StringToUTF16Ptr(strings.ReplaceAll(title, "\0", "�")),
 		uint32(style)))
 }


### PR DESCRIPTION
Go doesn't like NULs in the windows conversion functions and panics.
There's the newer variant but doesn't panic, but it just returns EINVAL
and doesn't help us. Since MsgBox is so useful for debugging, add an
explicit replacement.