### PR TITLE
Fix compatibility issue with Go before 1.11

### DIFF
--- a/messagebox.go
+++ b/messagebox.go
@@ -59,7 +59,7 @@ func MsgBox(owner Form, title, message string, style MsgBoxStyle) int {
 
 	return int(win.MessageBox(
 		ownerHWnd,
-		syscall.StringToUTF16Ptr(strings.ReplaceAll(message, "\x00", "␀")),
-		syscall.StringToUTF16Ptr(strings.ReplaceAll(title, "\x00", "␀")),
+		syscall.StringToUTF16Ptr(strings.Replace(message, "\x00", "␀", -1)),
+		syscall.StringToUTF16Ptr(strings.Replace(title, "\x00", "␀", -1)),
 		uint32(style)))
 }


### PR DESCRIPTION
Instead of using strings.ReplaceAll we just use strings.Replace with -1
as the last argument, which does the same but is a tiny bit less
readable. The value of backwards compatibility is more important.