### PR TITLE
tableview: use 96dpi for image heights

### DIFF
--- a/tableview.go
+++ b/tableview.go
@@ -1619,7 +1619,7 @@ func (tv *TableView) toggleItemChecked(index int) error {
 }
 
 func (tv *TableView) applyImageListForImage(image interface{}) {
-	tv.hIml, tv.usingSysIml, _ = imageListForImage(image, tv.DPI())
+	tv.hIml, tv.usingSysIml, _ = imageListForImage(image, 96)
 
 	tv.applyImageList()
 


### PR DESCRIPTION
Without this, rows get double-sized, having 2x height.

**I don't know how "correct" this commit is, but it seems to maybe work with WireGuard.**

CC @rozmansi