### PR TITLE
TableView: Upgrade alternating row color to follow theme changes

### DIFF
--- a/declarative/tableview.go
+++ b/declarative/tableview.go
@@ -48,7 +48,7 @@ type TableView struct {
 
 	// TableView
 
-	AlternatingRowBGColor       walk.Color
+	AlternatingRowBG            bool
 	AssignTo                    **walk.TableView
 	CellStyler                  walk.CellStyler
 	CheckBoxes                  bool
@@ -157,9 +157,7 @@ func (tv TableView) Create(builder *Builder) error {
 			w.SetCellStyler(styler)
 		}
 
-		if tv.AlternatingRowBGColor != 0 {
-			w.SetAlternatingRowBGColor(tv.AlternatingRowBGColor)
-		}
+		w.SetAlternatingRowBG(tv.AlternatingRowBG)
 		w.SetCheckBoxes(tv.CheckBoxes)
 		w.SetItemStateChangedEventDelay(tv.ItemStateChangedEventDelay)
 		if err := w.SetLastColumnStretched(tv.LastColumnStretched); err != nil {

--- a/examples/settings/settings.go
+++ b/examples/settings/settings.go
@@ -53,9 +53,9 @@ func RunMainWindow() error {
 		Layout:  VBox{MarginsZero: true},
 		Children: []Widget{
 			TableView{
-				Name: "tableView", // Name is needed for settings persistence
-				AlternatingRowBGColor: walk.RGB(255, 255, 200),
-				ColumnsOrderable:      true,
+				Name:             "tableView", // Name is needed for settings persistence
+				AlternatingRowBG: true,
+				ColumnsOrderable: true,
 				Columns: []TableViewColumn{
 					// Name is needed for settings persistence
 					{Name: "#", DataMember: "Index"}, // Use DataMember, if names differ

--- a/examples/tableview/tableview.go
+++ b/examples/tableview/tableview.go
@@ -177,11 +177,11 @@ func main() {
 				},
 			},
 			TableView{
-				AssignTo:              &tv,
-				AlternatingRowBGColor: walk.RGB(239, 239, 239),
-				CheckBoxes:            true,
-				ColumnsOrderable:      true,
-				MultiSelection:        true,
+				AssignTo:         &tv,
+				AlternatingRowBG: true,
+				CheckBoxes:       true,
+				ColumnsOrderable: true,
+				MultiSelection:   true,
 				Columns: []TableViewColumn{
 					{Title: "#"},
 					{Title: "Bar"},

--- a/tableview.go
+++ b/tableview.go
@@ -100,7 +100,8 @@ type TableView struct {
 	itemBGColor                        Color
 	itemTextColor                      Color
 	alternatingRowBGColor              Color
-	hasDarkAltBGColor                  bool
+	alternatingRowTextColor            Color
+	alternatingRowBG                   bool
 	delayedCurrentIndexChangedCanceled bool
 	sortedColumnIndex                  int
 	sortOrder                          SortOrder
@@ -398,34 +399,48 @@ func (tv *TableView) ApplySysColors() {
 	tv.themeSelectedBGColor = tv.themeNormalBGColor
 	tv.themeSelectedTextColor = tv.themeNormalTextColor
 	tv.themeSelectedNotFocusedBGColor = tv.themeNormalBGColor
+	tv.alternatingRowBGColor = Color(win.GetSysColor(win.COLOR_BTNFACE))
+	tv.alternatingRowTextColor = Color(win.GetSysColor(win.COLOR_BTNTEXT))
 
-	if hTheme := win.OpenThemeData(tv.hwndNormalLV, syscall.StringToUTF16Ptr("Listview")); hTheme != 0 {
-		defer win.CloseThemeData(hTheme)
+	type item struct {
+		stateID    int32
+		propertyID int32
+		color      *Color
+	}
 
-		type item struct {
-			stateID    int32
-			propertyID int32
-			color      *Color
+	getThemeColor := func(theme win.HTHEME, partId int32, items []item) {
+		for _, item := range items {
+			var c win.COLORREF
+			if result := win.GetThemeColor(theme, partId, item.stateID, item.propertyID, &c); !win.FAILED(result) {
+				(*item.color) = Color(c)
+			}
 		}
+	}
 
-		items := [...]item{
+	if hThemeListView := win.OpenThemeData(tv.hwndNormalLV, syscall.StringToUTF16Ptr("Listview")); hThemeListView != 0 {
+		defer win.CloseThemeData(hThemeListView)
+
+		getThemeColor(hThemeListView, win.LVP_LISTITEM, []item{
 			{win.LISS_NORMAL, win.TMT_FILLCOLOR, &tv.themeNormalBGColor},
 			{win.LISS_NORMAL, win.TMT_TEXTCOLOR, &tv.themeNormalTextColor},
 			{win.LISS_SELECTED, win.TMT_FILLCOLOR, &tv.themeSelectedBGColor},
 			{win.LISS_SELECTED, win.TMT_TEXTCOLOR, &tv.themeSelectedTextColor},
 			{win.LISS_SELECTEDNOTFOCUS, win.TMT_FILLCOLOR, &tv.themeSelectedNotFocusedBGColor},
-		}
-		for _, item := range items {
-			var c win.COLORREF
-			if result := win.GetThemeColor(hTheme, win.LVP_LISTITEM, item.stateID, item.propertyID, &c); !win.FAILED(result) {
-				(*item.color) = Color(c)
-			}
-		}
+		})
 	} else {
 		// The others already have been retrieved above.
 		tv.themeSelectedBGColor = Color(win.GetSysColor(win.COLOR_HIGHLIGHT))
 		tv.themeSelectedTextColor = Color(win.GetSysColor(win.COLOR_HIGHLIGHTTEXT))
 		tv.themeSelectedNotFocusedBGColor = Color(win.GetSysColor(win.COLOR_BTNFACE))
+	}
+
+	if hThemeButton := win.OpenThemeData(tv.hwndNormalLV, syscall.StringToUTF16Ptr("BUTTON")); hThemeButton != 0 {
+		defer win.CloseThemeData(hThemeButton)
+
+		getThemeColor(hThemeButton, win.BP_PUSHBUTTON, []item{
+			{win.PBS_NORMAL, win.TMT_FILLCOLOR, &tv.alternatingRowBGColor},
+			{win.PBS_NORMAL, win.TMT_TEXTCOLOR, &tv.alternatingRowTextColor},
+		})
 	}
 
 	win.SendMessage(tv.hwndNormalLV, win.LVM_SETBKCOLOR, 0, uintptr(tv.themeNormalBGColor))
@@ -538,16 +553,14 @@ func (tv *TableView) SetHeaderHidden(hidden bool) error {
 	return updateStyle(tv.hwndNormalLV)
 }
 
-// AlternatingRowBGColor returns the alternating row background color.
-func (tv *TableView) AlternatingRowBGColor() Color {
-	return tv.alternatingRowBGColor
+// AlternatingRowBG returns the alternating row background.
+func (tv *TableView) AlternatingRowBG() bool {
+	return tv.alternatingRowBG
 }
 
-// SetAlternatingRowBGColor sets the alternating row background color.
-func (tv *TableView) SetAlternatingRowBGColor(c Color) {
-	tv.alternatingRowBGColor = c
-
-	tv.hasDarkAltBGColor = int(c.R())+int(c.G())+int(c.B()) < 128*3
+// SetAlternatingRowBG sets the alternating row background.
+func (tv *TableView) SetAlternatingRowBG(enabled bool) {
+	tv.alternatingRowBG = enabled
 
 	tv.Invalidate()
 }
@@ -1979,8 +1992,9 @@ func (tv *TableView) lvWndProc(origWndProcPtr uintptr, hwnd win.HWND, msg uint32
 						tv.itemTextColor = tv.themeNormalTextColor
 					}
 
-					if !selected && tv.alternatingRowBGColor != 0 && row%2 == 1 {
+					if !selected && tv.alternatingRowBG && row%2 == 1 {
 						tv.itemBGColor = tv.alternatingRowBGColor
+						tv.itemTextColor = tv.alternatingRowTextColor
 					}
 
 					tv.style.BackgroundColor = tv.itemBGColor


### PR DESCRIPTION
The alternating row color has been revised to respond to dynamic theme changes. The alternating row color is now fixed to follow the push-button text and background color. Instead of setting a custom alternating row background color, a client may now enable or disable the alternating effect only. Well, the client had no way to customize other colors already.

hasDarkAltBGColor appeared unused and was removed.

_Note: Breaks backward compatibility with existing lxn/walk clients. The AlternatingRowBGColor() and SetAlternatingRowBGColor() were replaced by AlternatingRowBG() and SetAlternatingRowBG()._

_Note: Requires https://github.com/lxn/win/pull/87_