### PR TITLE
Do not use global init functions

### DIFF
--- a/brush.go
+++ b/brush.go
@@ -151,7 +151,10 @@ func (*nullBrush) simple() bool {
 	return true
 }
 
-var nullBrushSingleton Brush = newNullBrush()
+var (
+	nullBrushSingleton   Brush
+	sysColorBtnFaceBrush *SystemColorBrush
+)
 
 func NullBrush() Brush {
 	return nullBrushSingleton
@@ -162,7 +165,12 @@ type SystemColorBrush struct {
 	sysColor SystemColor
 }
 
-var sysColorBtnFaceBrush, _ = NewSystemColorBrush(SysColorBtnFace)
+func init() {
+	AppendToWalkInit(func() {
+		nullBrushSingleton = newNullBrush()
+		sysColorBtnFaceBrush, _ = NewSystemColorBrush(SysColorBtnFace)
+	})
+}
 
 func NewSystemColorBrush(sysColor SystemColor) (*SystemColorBrush, error) {
 	hBrush := win.GetSysColorBrush(int(sysColor))
@@ -195,8 +203,6 @@ func (b *SystemColorBrush) logbrush() *win.LOGBRUSH {
 func (*SystemColorBrush) simple() bool {
 	return true
 }
-
-var sysColorBtnFaceBrushSingleton, _ = NewSystemColorBrush(SysColorBtnFace)
 
 type SolidColorBrush struct {
 	brushBase

--- a/canvas.go
+++ b/canvas.go
@@ -43,7 +43,13 @@ const (
 	TextPrefixOnly           DrawTextFormat = win.DT_PREFIXONLY
 )
 
-var gM = syscall.StringToUTF16Ptr("gM")
+var gM *uint16
+
+func init() {
+	AppendToWalkInit(func() {
+		gM = syscall.StringToUTF16Ptr("gM")
+	})
+}
 
 type Canvas struct {
 	hdc                 win.HDC

--- a/clipboard.go
+++ b/clipboard.go
@@ -9,40 +9,40 @@ package walk
 import (
 	"syscall"
 	"unsafe"
-)
 
-import (
 	"github.com/lxn/win"
 )
 
 const clipboardWindowClass = `\o/ Walk_Clipboard_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(clipboardWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClassWithWndProcPtr(clipboardWindowClass, syscall.NewCallback(clipboardWndProc))
 
-	hwnd := win.CreateWindowEx(
-		0,
-		syscall.StringToUTF16Ptr(clipboardWindowClass),
-		nil,
-		0,
-		0,
-		0,
-		0,
-		0,
-		win.HWND_MESSAGE,
-		0,
-		0,
-		nil)
+		hwnd := win.CreateWindowEx(
+			0,
+			syscall.StringToUTF16Ptr(clipboardWindowClass),
+			nil,
+			0,
+			0,
+			0,
+			0,
+			0,
+			win.HWND_MESSAGE,
+			0,
+			0,
+			nil)
 
-	if hwnd == 0 {
-		panic("failed to create clipboard window")
-	}
+		if hwnd == 0 {
+			panic("failed to create clipboard window")
+		}
 
-	if !win.AddClipboardFormatListener(hwnd) {
-		lastError("AddClipboardFormatListener")
-	}
+		if !win.AddClipboardFormatListener(hwnd) {
+			lastError("AddClipboardFormatListener")
+		}
 
-	clipboard.hwnd = hwnd
+		clipboard.hwnd = hwnd
+	})
 }
 
 func clipboardWndProc(hwnd win.HWND, msg uint32, wp, lp uintptr) uintptr {

--- a/combobox.go
+++ b/combobox.go
@@ -43,7 +43,13 @@ type ComboBox struct {
 	persistent                   bool
 }
 
-var comboBoxEditWndProcPtr = syscall.NewCallback(comboBoxEditWndProc)
+var comboBoxEditWndProcPtr uintptr
+
+func init() {
+	AppendToWalkInit(func() {
+		comboBoxEditWndProcPtr = syscall.NewCallback(comboBoxEditWndProc)
+	})
+}
 
 func comboBoxEditWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) uintptr {
 	cb := (*ComboBox)(unsafe.Pointer(win.GetWindowLongPtr(hwnd, win.GWLP_USERDATA)))

--- a/composite.go
+++ b/composite.go
@@ -13,7 +13,9 @@ import (
 const compositeWindowClass = `\o/ Walk_Composite_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(compositeWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(compositeWindowClass)
+	})
 }
 
 type Composite struct {

--- a/container.go
+++ b/container.go
@@ -478,7 +478,13 @@ func firstFocusableDescendantCallback(hwnd win.HWND, lParam uintptr) uintptr {
 	return 1
 }
 
-var firstFocusableDescendantCallbackPtr = syscall.NewCallback(firstFocusableDescendantCallback)
+var firstFocusableDescendantCallbackPtr uintptr
+
+func init() {
+	AppendToWalkInit(func() {
+		firstFocusableDescendantCallbackPtr = syscall.NewCallback(firstFocusableDescendantCallback)
+	})
+}
 
 func firstFocusableDescendant(container Container) Window {
 	var hwnd win.HWND

--- a/customwidget.go
+++ b/customwidget.go
@@ -15,7 +15,9 @@ import (
 const customWidgetWindowClass = `\o/ Walk_CustomWidget_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(customWidgetWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(customWidgetWindowClass)
+	})
 }
 
 type PaintFunc func(canvas *Canvas, updateBounds Rectangle) error

--- a/declarative/builder.go
+++ b/declarative/builder.go
@@ -22,8 +22,14 @@ import (
 
 var (
 	conditionsByName = make(map[string]walk.Condition)
-	propertyRE       = regexp.MustCompile("[A-Za-z]+[0-9A-Za-z]*(\\.[A-Za-z]+[0-9A-Za-z]*)+")
+	propertyRE       *regexp.Regexp
 )
+
+func init() {
+	walk.AppendToWalkInit(func() {
+		propertyRE = regexp.MustCompile("[A-Za-z]+[0-9A-Za-z]*(\\.[A-Za-z]+[0-9A-Za-z]*)+")
+	})
+}
 
 func MustRegisterCondition(name string, condition walk.Condition) {
 	if name == "" {

--- a/declarative/mainwindow.go
+++ b/declarative/mainwindow.go
@@ -47,15 +47,15 @@ type MainWindow struct {
 
 	// MainWindow
 
-	AssignTo       **walk.MainWindow
-	Expressions    func() map[string]walk.Expression
-	Functions      map[string]func(args ...interface{}) (interface{}, error)
-	MenuItems      []MenuItem
-	OnDropFiles    walk.DropFilesEventHandler
-	StatusBarItems []StatusBarItem
+	AssignTo          **walk.MainWindow
+	Expressions       func() map[string]walk.Expression
+	Functions         map[string]func(args ...interface{}) (interface{}, error)
+	MenuItems         []MenuItem
+	OnDropFiles       walk.DropFilesEventHandler
+	StatusBarItems    []StatusBarItem
 	SuspendedUntilRun bool
-	ToolBar        ToolBar
-	ToolBarItems   []MenuItem // Deprecated: use ToolBar instead
+	ToolBar           ToolBar
+	ToolBarItems      []MenuItem // Deprecated: use ToolBar instead
 }
 
 func (mw MainWindow) Create() error {

--- a/dialog.go
+++ b/dialog.go
@@ -31,7 +31,9 @@ const (
 const dialogWindowClass = `\o/ Walk_Dialog_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(dialogWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(dialogWindowClass)
+	})
 }
 
 type dialogish interface {

--- a/font.go
+++ b/font.go
@@ -32,17 +32,19 @@ var (
 )
 
 func init() {
-	// Retrieve screen DPI
-	hDC := win.GetDC(0)
-	defer win.ReleaseDC(0, hDC)
-	screenDPIX = int(win.GetDeviceCaps(hDC, win.LOGPIXELSX))
-	screenDPIY = int(win.GetDeviceCaps(hDC, win.LOGPIXELSY))
+	AppendToWalkInit(func() {
+		// Retrieve screen DPI
+		hDC := win.GetDC(0)
+		defer win.ReleaseDC(0, hDC)
+		screenDPIX = int(win.GetDeviceCaps(hDC, win.LOGPIXELSX))
+		screenDPIY = int(win.GetDeviceCaps(hDC, win.LOGPIXELSY))
 
-	// Initialize default font
-	var err error
-	if defaultFont, err = NewFont("MS Shell Dlg 2", 8, 0); err != nil {
-		panic("failed to create default font")
-	}
+		// Initialize default font
+		var err error
+		if defaultFont, err = NewFont("MS Shell Dlg 2", 8, 0); err != nil {
+			panic("failed to create default font")
+		}
+	})
 }
 
 type fontInfo struct {

--- a/form.go
+++ b/form.go
@@ -36,8 +36,10 @@ var (
 )
 
 func init() {
-	syncMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("WalkSync"))
-	taskbarButtonCreatedMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("TaskbarButtonCreated"))
+	AppendToWalkInit(func() {
+		syncMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("WalkSync"))
+		taskbarButtonCreatedMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("TaskbarButtonCreated"))
+	})
 }
 
 type applyLayoutResultsArgs struct {

--- a/groupbox.go
+++ b/groupbox.go
@@ -16,7 +16,9 @@ import (
 const groupBoxWindowClass = `\o/ Walk_GroupBox_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(groupBoxWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(groupBoxWindowClass)
+	})
 }
 
 type GroupBox struct {

--- a/icon.go
+++ b/icon.go
@@ -20,7 +20,9 @@ import (
 var defaultIconSize Size
 
 func init() {
-	defaultIconSize = Size{int(win.GetSystemMetricsForDpi(win.SM_CXSMICON, 96)), int(win.GetSystemMetricsForDpi(win.SM_CYSMICON, 96))}
+	AppendToWalkInit(func() {
+		defaultIconSize = Size{int(win.GetSystemMetricsForDpi(win.SM_CXSMICON, 96)), int(win.GetSystemMetricsForDpi(win.SM_CYSMICON, 96))}
+	})
 }
 
 // Icon is a bitmap that supports transparency and combining multiple

--- a/iconcache.go
+++ b/iconcache.go
@@ -6,7 +6,13 @@
 
 package walk
 
-var iconCache = NewIconCache()
+var iconCache *IconCache
+
+func init() {
+	AppendToWalkInit(func() {
+		iconCache = NewIconCache()
+	})
+}
 
 type IconCache struct {
 	imageAndDPI2Bitmap map[imageAndDPI]*Bitmap

--- a/mainwindow.go
+++ b/mainwindow.go
@@ -17,7 +17,9 @@ import (
 const mainWindowWindowClass = `\o/ Walk_MainWindow_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(mainWindowWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(mainWindowWindowClass)
+	})
 }
 
 type MainWindow struct {

--- a/numberedit.go
+++ b/numberedit.go
@@ -21,7 +21,9 @@ import (
 const numberEditWindowClass = `\o/ Walk_NumberEdit_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(numberEditWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(numberEditWindowClass)
+	})
 }
 
 // NumberEdit is a widget that is suited to edit numeric values.

--- a/pen.go
+++ b/pen.go
@@ -81,7 +81,13 @@ func (p *nullPen) Width() int {
 	return 0
 }
 
-var nullPenSingleton Pen = newNullPen()
+var nullPenSingleton Pen
+
+func init() {
+	AppendToWalkInit(func() {
+		nullPenSingleton = newNullPen()
+	})
+}
 
 func NullPen() Pen {
 	return nullPenSingleton

--- a/resourcemanager.go
+++ b/resourcemanager.go
@@ -14,9 +14,11 @@ import (
 )
 
 func init() {
-	Resources.rootDirPath, _ = os.Getwd()
-	Resources.bitmaps = make(map[string]*Bitmap)
-	Resources.icons = make(map[string]*Icon)
+	AppendToWalkInit(func() {
+		Resources.rootDirPath, _ = os.Getwd()
+		Resources.bitmaps = make(map[string]*Bitmap)
+		Resources.icons = make(map[string]*Icon)
+	})
 }
 
 // Resources is the singleton instance of ResourceManager.

--- a/scrollview.go
+++ b/scrollview.go
@@ -15,7 +15,9 @@ import (
 const scrollViewWindowClass = `\o/ Walk_ScrollView_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(scrollViewWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(scrollViewWindowClass)
+	})
 }
 
 type ScrollView struct {

--- a/spacer.go
+++ b/spacer.go
@@ -9,7 +9,9 @@ package walk
 const spacerWindowClass = `\o/ Walk_Spacer_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(spacerWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(spacerWindowClass)
+	})
 }
 
 type Spacer struct {

--- a/splitter.go
+++ b/splitter.go
@@ -21,10 +21,12 @@ const splitterWindowClass = `\o/ Walk_Splitter_Class \o/`
 var splitterHandleDraggingBrush *SolidColorBrush
 
 func init() {
-	MustRegisterWindowClass(splitterWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(splitterWindowClass)
 
-	splitterHandleDraggingBrush, _ = NewSolidColorBrush(Color(win.GetSysColor(win.COLOR_BTNSHADOW)))
-	splitterHandleDraggingBrush.wb2info = map[*WindowBase]*windowBrushInfo{nil: nil}
+		splitterHandleDraggingBrush, _ = NewSolidColorBrush(Color(win.GetSysColor(win.COLOR_BTNSHADOW)))
+		splitterHandleDraggingBrush.wb2info = map[*WindowBase]*windowBrushInfo{nil: nil}
+	})
 }
 
 type Splitter struct {

--- a/splitterhandle.go
+++ b/splitterhandle.go
@@ -13,7 +13,9 @@ import (
 const splitterHandleWindowClass = `\o/ Walk_SplitterHandle_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(splitterHandleWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(splitterHandleWindowClass)
+	})
 }
 
 type splitterHandle struct {

--- a/static.go
+++ b/static.go
@@ -15,10 +15,13 @@ import (
 
 const staticWindowClass = `\o/ Walk_Static_Class \o/`
 
-var staticWndProcPtr = syscall.NewCallback(staticWndProc)
+var staticWndProcPtr uintptr
 
 func init() {
-	MustRegisterWindowClass(staticWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(staticWindowClass)
+		staticWndProcPtr = syscall.NewCallback(staticWndProc)
+	})
 }
 
 type static struct {

--- a/tableview.go
+++ b/tableview.go
@@ -20,17 +20,22 @@ import (
 
 const tableViewWindowClass = `\o/ Walk_TableView_Class \o/`
 
-func init() {
-	MustRegisterWindowClass(tableViewWindowClass)
-}
-
 var (
 	white                       = win.COLORREF(RGB(255, 255, 255))
 	checkmark                   = string([]byte{0xE2, 0x9C, 0x94})
-	tableViewFrozenLVWndProcPtr = syscall.NewCallback(tableViewFrozenLVWndProc)
-	tableViewNormalLVWndProcPtr = syscall.NewCallback(tableViewNormalLVWndProc)
-	tableViewHdrWndProcPtr      = syscall.NewCallback(tableViewHdrWndProc)
+	tableViewFrozenLVWndProcPtr uintptr
+	tableViewNormalLVWndProcPtr uintptr
+	tableViewHdrWndProcPtr      uintptr
 )
+
+func init() {
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(tableViewWindowClass)
+		tableViewFrozenLVWndProcPtr = syscall.NewCallback(tableViewFrozenLVWndProc)
+		tableViewNormalLVWndProcPtr = syscall.NewCallback(tableViewNormalLVWndProc)
+		tableViewHdrWndProcPtr = syscall.NewCallback(tableViewHdrWndProc)
+	})
+}
 
 const (
 	tableViewCurrentIndexChangedTimerId = 1 + iota

--- a/tabpage.go
+++ b/tabpage.go
@@ -17,9 +17,11 @@ const tabPageWindowClass = `\o/ Walk_TabPage_Class \o/`
 var tabPageBackgroundBrush Brush
 
 func init() {
-	MustRegisterWindowClass(tabPageWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(tabPageWindowClass)
 
-	tabPageBackgroundBrush, _ = NewSystemColorBrush(win.COLOR_WINDOW)
+		tabPageBackgroundBrush, _ = NewSystemColorBrush(win.COLOR_WINDOW)
+	})
 }
 
 type TabPage struct {

--- a/tabwidget.go
+++ b/tabwidget.go
@@ -17,7 +17,10 @@ import (
 const tabWidgetWindowClass = `\o/ Walk_TabWidget_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(tabWidgetWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(tabWidgetWindowClass)
+		tabWidgetTabWndProcPtr = syscall.NewCallback(tabWidgetTabWndProc)
+	})
 }
 
 type TabWidget struct {
@@ -325,7 +328,7 @@ func (tw *TabWidget) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) 
 	return tw.WidgetBase.WndProc(hwnd, msg, wParam, lParam)
 }
 
-var tabWidgetTabWndProcPtr = syscall.NewCallback(tabWidgetTabWndProc)
+var tabWidgetTabWndProcPtr uintptr
 
 func tabWidgetTabWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) uintptr {
 	tw := (*TabWidget)(unsafe.Pointer(win.GetWindowLongPtr(hwnd, win.GWLP_USERDATA)))

--- a/textedit.go
+++ b/textedit.go
@@ -94,7 +94,13 @@ func (te *TextEdit) updateMargins() {
 	te.margins.Height = defaultSize.Height - lineHeight
 }
 
-var drawTextCompatibleEditWordbreakProcPtr = syscall.NewCallback(drawTextCompatibleEditWordbreakProc)
+var drawTextCompatibleEditWordbreakProcPtr uintptr
+
+func init() {
+	AppendToWalkInit(func() {
+		drawTextCompatibleEditWordbreakProcPtr = syscall.NewCallback(drawTextCompatibleEditWordbreakProc)
+	})
+}
 
 func drawTextCompatibleEditWordbreakProc(lpch *uint16, ichCurrent, cch, code uintptr) uintptr {
 	switch code {

--- a/tooltip.go
+++ b/tooltip.go
@@ -21,10 +21,12 @@ import (
 const maxToolTipTextLen = 1024 // including NUL terminator
 
 func init() {
-	var err error
-	if globalToolTip, err = NewToolTip(); err != nil {
-		panic(err)
-	}
+	AppendToWalkInit(func() {
+		var err error
+		if globalToolTip, err = NewToolTip(); err != nil {
+			panic(err)
+		}
+	})
 }
 
 type ToolTip struct {

--- a/util.go
+++ b/util.go
@@ -28,17 +28,19 @@ var (
 )
 
 func init() {
-	var buf [4]uint16
+	AppendToWalkInit(func() {
+		var buf [4]uint16
 
-	win.GetLocaleInfo(win.LOCALE_USER_DEFAULT, win.LOCALE_SDECIMAL, &buf[0], int32(len(buf)))
-	decimalSepB = byte(buf[0])
-	decimalSepS = syscall.UTF16ToString(buf[0:1])
-	decimalSepUint16 = buf[0]
+		win.GetLocaleInfo(win.LOCALE_USER_DEFAULT, win.LOCALE_SDECIMAL, &buf[0], int32(len(buf)))
+		decimalSepB = byte(buf[0])
+		decimalSepS = syscall.UTF16ToString(buf[0:1])
+		decimalSepUint16 = buf[0]
 
-	win.GetLocaleInfo(win.LOCALE_USER_DEFAULT, win.LOCALE_STHOUSAND, &buf[0], int32(len(buf)))
-	groupSepB = byte(buf[0])
-	groupSepS = syscall.UTF16ToString(buf[0:1])
-	groupSepUint16 = buf[0]
+		win.GetLocaleInfo(win.LOCALE_USER_DEFAULT, win.LOCALE_STHOUSAND, &buf[0], int32(len(buf)))
+		groupSepB = byte(buf[0])
+		groupSepS = syscall.UTF16ToString(buf[0:1])
+		groupSepUint16 = buf[0]
+	})
 }
 
 func maxi(a, b int) int {

--- a/webview.go
+++ b/webview.go
@@ -19,7 +19,9 @@ import (
 const webViewWindowClass = `\o/ Walk_WebView_Class \o/`
 
 func init() {
-	MustRegisterWindowClass(webViewWindowClass)
+	AppendToWalkInit(func() {
+		MustRegisterWindowClass(webViewWindowClass)
+	})
 }
 
 type WebView struct {

--- a/webview_dwebbrowserevents2.go
+++ b/webview_dwebbrowserevents2.go
@@ -20,15 +20,17 @@ import (
 var webViewDWebBrowserEvents2Vtbl *win.DWebBrowserEvents2Vtbl
 
 func init() {
-	webViewDWebBrowserEvents2Vtbl = &win.DWebBrowserEvents2Vtbl{
-		syscall.NewCallback(webView_DWebBrowserEvents2_QueryInterface),
-		syscall.NewCallback(webView_DWebBrowserEvents2_AddRef),
-		syscall.NewCallback(webView_DWebBrowserEvents2_Release),
-		syscall.NewCallback(webView_DWebBrowserEvents2_GetTypeInfoCount),
-		syscall.NewCallback(webView_DWebBrowserEvents2_GetTypeInfo),
-		syscall.NewCallback(webView_DWebBrowserEvents2_GetIDsOfNames),
-		syscall.NewCallback(webView_DWebBrowserEvents2_Invoke),
-	}
+	AppendToWalkInit(func() {
+		webViewDWebBrowserEvents2Vtbl = &win.DWebBrowserEvents2Vtbl{
+			syscall.NewCallback(webView_DWebBrowserEvents2_QueryInterface),
+			syscall.NewCallback(webView_DWebBrowserEvents2_AddRef),
+			syscall.NewCallback(webView_DWebBrowserEvents2_Release),
+			syscall.NewCallback(webView_DWebBrowserEvents2_GetTypeInfoCount),
+			syscall.NewCallback(webView_DWebBrowserEvents2_GetTypeInfo),
+			syscall.NewCallback(webView_DWebBrowserEvents2_GetIDsOfNames),
+			syscall.NewCallback(webView_DWebBrowserEvents2_Invoke),
+		}
+	})
 }
 
 type webViewDWebBrowserEvents2 struct {

--- a/webview_idochostuihandler.go
+++ b/webview_idochostuihandler.go
@@ -18,26 +18,28 @@ import (
 var webViewIDocHostUIHandlerVtbl *win.IDocHostUIHandlerVtbl
 
 func init() {
-	webViewIDocHostUIHandlerVtbl = &win.IDocHostUIHandlerVtbl{
-		syscall.NewCallback(webView_IDocHostUIHandler_QueryInterface),
-		syscall.NewCallback(webView_IDocHostUIHandler_AddRef),
-		syscall.NewCallback(webView_IDocHostUIHandler_Release),
-		syscall.NewCallback(webView_IDocHostUIHandler_ShowContextMenu),
-		syscall.NewCallback(webView_IDocHostUIHandler_GetHostInfo),
-		syscall.NewCallback(webView_IDocHostUIHandler_ShowUI),
-		syscall.NewCallback(webView_IDocHostUIHandler_HideUI),
-		syscall.NewCallback(webView_IDocHostUIHandler_UpdateUI),
-		syscall.NewCallback(webView_IDocHostUIHandler_EnableModeless),
-		syscall.NewCallback(webView_IDocHostUIHandler_OnDocWindowActivate),
-		syscall.NewCallback(webView_IDocHostUIHandler_OnFrameWindowActivate),
-		syscall.NewCallback(webView_IDocHostUIHandler_ResizeBorder),
-		syscall.NewCallback(webView_IDocHostUIHandler_TranslateAccelerator),
-		syscall.NewCallback(webView_IDocHostUIHandler_GetOptionKeyPath),
-		syscall.NewCallback(webView_IDocHostUIHandler_GetDropTarget),
-		syscall.NewCallback(webView_IDocHostUIHandler_GetExternal),
-		syscall.NewCallback(webView_IDocHostUIHandler_TranslateUrl),
-		syscall.NewCallback(webView_IDocHostUIHandler_FilterDataObject),
-	}
+	AppendToWalkInit(func() {
+		webViewIDocHostUIHandlerVtbl = &win.IDocHostUIHandlerVtbl{
+			syscall.NewCallback(webView_IDocHostUIHandler_QueryInterface),
+			syscall.NewCallback(webView_IDocHostUIHandler_AddRef),
+			syscall.NewCallback(webView_IDocHostUIHandler_Release),
+			syscall.NewCallback(webView_IDocHostUIHandler_ShowContextMenu),
+			syscall.NewCallback(webView_IDocHostUIHandler_GetHostInfo),
+			syscall.NewCallback(webView_IDocHostUIHandler_ShowUI),
+			syscall.NewCallback(webView_IDocHostUIHandler_HideUI),
+			syscall.NewCallback(webView_IDocHostUIHandler_UpdateUI),
+			syscall.NewCallback(webView_IDocHostUIHandler_EnableModeless),
+			syscall.NewCallback(webView_IDocHostUIHandler_OnDocWindowActivate),
+			syscall.NewCallback(webView_IDocHostUIHandler_OnFrameWindowActivate),
+			syscall.NewCallback(webView_IDocHostUIHandler_ResizeBorder),
+			syscall.NewCallback(webView_IDocHostUIHandler_TranslateAccelerator),
+			syscall.NewCallback(webView_IDocHostUIHandler_GetOptionKeyPath),
+			syscall.NewCallback(webView_IDocHostUIHandler_GetDropTarget),
+			syscall.NewCallback(webView_IDocHostUIHandler_GetExternal),
+			syscall.NewCallback(webView_IDocHostUIHandler_TranslateUrl),
+			syscall.NewCallback(webView_IDocHostUIHandler_FilterDataObject),
+		}
+	})
 }
 
 type webViewIDocHostUIHandler struct {

--- a/webview_ioleclientsite.go
+++ b/webview_ioleclientsite.go
@@ -18,17 +18,19 @@ import (
 var webViewIOleClientSiteVtbl *win.IOleClientSiteVtbl
 
 func init() {
-	webViewIOleClientSiteVtbl = &win.IOleClientSiteVtbl{
-		syscall.NewCallback(webView_IOleClientSite_QueryInterface),
-		syscall.NewCallback(webView_IOleClientSite_AddRef),
-		syscall.NewCallback(webView_IOleClientSite_Release),
-		syscall.NewCallback(webView_IOleClientSite_SaveObject),
-		syscall.NewCallback(webView_IOleClientSite_GetMoniker),
-		syscall.NewCallback(webView_IOleClientSite_GetContainer),
-		syscall.NewCallback(webView_IOleClientSite_ShowObject),
-		syscall.NewCallback(webView_IOleClientSite_OnShowWindow),
-		syscall.NewCallback(webView_IOleClientSite_RequestNewObjectLayout),
-	}
+	AppendToWalkInit(func() {
+		webViewIOleClientSiteVtbl = &win.IOleClientSiteVtbl{
+			syscall.NewCallback(webView_IOleClientSite_QueryInterface),
+			syscall.NewCallback(webView_IOleClientSite_AddRef),
+			syscall.NewCallback(webView_IOleClientSite_Release),
+			syscall.NewCallback(webView_IOleClientSite_SaveObject),
+			syscall.NewCallback(webView_IOleClientSite_GetMoniker),
+			syscall.NewCallback(webView_IOleClientSite_GetContainer),
+			syscall.NewCallback(webView_IOleClientSite_ShowObject),
+			syscall.NewCallback(webView_IOleClientSite_OnShowWindow),
+			syscall.NewCallback(webView_IOleClientSite_RequestNewObjectLayout),
+		}
+	})
 }
 
 type webViewIOleClientSite struct {

--- a/webview_ioleinplaceframe.go
+++ b/webview_ioleinplaceframe.go
@@ -17,23 +17,25 @@ import (
 var webViewIOleInPlaceFrameVtbl *win.IOleInPlaceFrameVtbl
 
 func init() {
-	webViewIOleInPlaceFrameVtbl = &win.IOleInPlaceFrameVtbl{
-		syscall.NewCallback(webView_IOleInPlaceFrame_QueryInterface),
-		syscall.NewCallback(webView_IOleInPlaceFrame_AddRef),
-		syscall.NewCallback(webView_IOleInPlaceFrame_Release),
-		syscall.NewCallback(webView_IOleInPlaceFrame_GetWindow),
-		syscall.NewCallback(webView_IOleInPlaceFrame_ContextSensitiveHelp),
-		syscall.NewCallback(webView_IOleInPlaceFrame_GetBorder),
-		syscall.NewCallback(webView_IOleInPlaceFrame_RequestBorderSpace),
-		syscall.NewCallback(webView_IOleInPlaceFrame_SetBorderSpace),
-		syscall.NewCallback(webView_IOleInPlaceFrame_SetActiveObject),
-		syscall.NewCallback(webView_IOleInPlaceFrame_InsertMenus),
-		syscall.NewCallback(webView_IOleInPlaceFrame_SetMenu),
-		syscall.NewCallback(webView_IOleInPlaceFrame_RemoveMenus),
-		syscall.NewCallback(webView_IOleInPlaceFrame_SetStatusText),
-		syscall.NewCallback(webView_IOleInPlaceFrame_EnableModeless),
-		syscall.NewCallback(webView_IOleInPlaceFrame_TranslateAccelerator),
-	}
+	AppendToWalkInit(func() {
+		webViewIOleInPlaceFrameVtbl = &win.IOleInPlaceFrameVtbl{
+			syscall.NewCallback(webView_IOleInPlaceFrame_QueryInterface),
+			syscall.NewCallback(webView_IOleInPlaceFrame_AddRef),
+			syscall.NewCallback(webView_IOleInPlaceFrame_Release),
+			syscall.NewCallback(webView_IOleInPlaceFrame_GetWindow),
+			syscall.NewCallback(webView_IOleInPlaceFrame_ContextSensitiveHelp),
+			syscall.NewCallback(webView_IOleInPlaceFrame_GetBorder),
+			syscall.NewCallback(webView_IOleInPlaceFrame_RequestBorderSpace),
+			syscall.NewCallback(webView_IOleInPlaceFrame_SetBorderSpace),
+			syscall.NewCallback(webView_IOleInPlaceFrame_SetActiveObject),
+			syscall.NewCallback(webView_IOleInPlaceFrame_InsertMenus),
+			syscall.NewCallback(webView_IOleInPlaceFrame_SetMenu),
+			syscall.NewCallback(webView_IOleInPlaceFrame_RemoveMenus),
+			syscall.NewCallback(webView_IOleInPlaceFrame_SetStatusText),
+			syscall.NewCallback(webView_IOleInPlaceFrame_EnableModeless),
+			syscall.NewCallback(webView_IOleInPlaceFrame_TranslateAccelerator),
+		}
+	})
 }
 
 type webViewIOleInPlaceFrame struct {

--- a/webview_ioleinplacesite.go
+++ b/webview_ioleinplacesite.go
@@ -18,23 +18,25 @@ import (
 var webViewIOleInPlaceSiteVtbl *win.IOleInPlaceSiteVtbl
 
 func init() {
-	webViewIOleInPlaceSiteVtbl = &win.IOleInPlaceSiteVtbl{
-		syscall.NewCallback(webView_IOleInPlaceSite_QueryInterface),
-		syscall.NewCallback(webView_IOleInPlaceSite_AddRef),
-		syscall.NewCallback(webView_IOleInPlaceSite_Release),
-		syscall.NewCallback(webView_IOleInPlaceSite_GetWindow),
-		syscall.NewCallback(webView_IOleInPlaceSite_ContextSensitiveHelp),
-		syscall.NewCallback(webView_IOleInPlaceSite_CanInPlaceActivate),
-		syscall.NewCallback(webView_IOleInPlaceSite_OnInPlaceActivate),
-		syscall.NewCallback(webView_IOleInPlaceSite_OnUIActivate),
-		syscall.NewCallback(webView_IOleInPlaceSite_GetWindowContext),
-		syscall.NewCallback(webView_IOleInPlaceSite_Scroll),
-		syscall.NewCallback(webView_IOleInPlaceSite_OnUIDeactivate),
-		syscall.NewCallback(webView_IOleInPlaceSite_OnInPlaceDeactivate),
-		syscall.NewCallback(webView_IOleInPlaceSite_DiscardUndoState),
-		syscall.NewCallback(webView_IOleInPlaceSite_DeactivateAndUndo),
-		syscall.NewCallback(webView_IOleInPlaceSite_OnPosRectChange),
-	}
+	AppendToWalkInit(func() {
+		webViewIOleInPlaceSiteVtbl = &win.IOleInPlaceSiteVtbl{
+			syscall.NewCallback(webView_IOleInPlaceSite_QueryInterface),
+			syscall.NewCallback(webView_IOleInPlaceSite_AddRef),
+			syscall.NewCallback(webView_IOleInPlaceSite_Release),
+			syscall.NewCallback(webView_IOleInPlaceSite_GetWindow),
+			syscall.NewCallback(webView_IOleInPlaceSite_ContextSensitiveHelp),
+			syscall.NewCallback(webView_IOleInPlaceSite_CanInPlaceActivate),
+			syscall.NewCallback(webView_IOleInPlaceSite_OnInPlaceActivate),
+			syscall.NewCallback(webView_IOleInPlaceSite_OnUIActivate),
+			syscall.NewCallback(webView_IOleInPlaceSite_GetWindowContext),
+			syscall.NewCallback(webView_IOleInPlaceSite_Scroll),
+			syscall.NewCallback(webView_IOleInPlaceSite_OnUIDeactivate),
+			syscall.NewCallback(webView_IOleInPlaceSite_OnInPlaceDeactivate),
+			syscall.NewCallback(webView_IOleInPlaceSite_DiscardUndoState),
+			syscall.NewCallback(webView_IOleInPlaceSite_DeactivateAndUndo),
+			syscall.NewCallback(webView_IOleInPlaceSite_OnPosRectChange),
+		}
+	})
 }
 
 type webViewIOleInPlaceSite struct {

--- a/window.go
+++ b/window.go
@@ -517,6 +517,12 @@ func InitWindow(window, parent Window, className string, style, exStyle uint32) 
 	// We can't use sync.Once, because tooltip.go's init also calls InitWindow, so we deadlock.
 	if atomic.CompareAndSwapUint32(&initedWalk, 0, 1) {
 		runtime.LockOSThread()
+
+		var initCtrls win.INITCOMMONCONTROLSEX
+		initCtrls.DwSize = uint32(unsafe.Sizeof(initCtrls))
+		initCtrls.DwICC = win.ICC_LINK_CLASS | win.ICC_LISTVIEW_CLASSES | win.ICC_PROGRESS_CLASS | win.ICC_TAB_CLASSES | win.ICC_TREEVIEW_CLASSES
+		win.InitCommonControlsEx(&initCtrls)
+
 		defaultWndProcPtr = syscall.NewCallback(defaultWndProc)
 		for _, fn := range walkInit {
 			fn()


### PR DESCRIPTION
This allows walk to be used inside other applications without the overhead of the UI parts aren't used.