### PR TITLE
Provide reasonable context menu location when invoked by keyboard

### DIFF
--- a/form.go
+++ b/form.go
@@ -332,6 +332,10 @@ func (fb *FormBase) SetContextMenu(contextMenu *Menu) {
 	fb.clientComposite.SetContextMenu(contextMenu)
 }
 
+func (fb *FormBase) ContextMenuLocation() Point {
+	return fb.clientComposite.ContextMenuLocation()
+}
+
 func (fb *FormBase) applyEnabled(enabled bool) {
 	fb.WindowBase.applyEnabled(enabled)
 

--- a/tableview.go
+++ b/tableview.go
@@ -525,6 +525,24 @@ func (tv *TableView) SetColumnsSizable(b bool) error {
 	return nil
 }
 
+// ContextMenuLocation returns selected item position in screen coordinates.
+func (tv *TableView) ContextMenuLocation() Point {
+	idx := win.SendMessage(tv.hwndNormalLV, win.LVM_GETSELECTIONMARK, 0, 0)
+	rc := win.RECT{Left: win.LVIR_BOUNDS}
+	if 0 == win.SendMessage(tv.hwndNormalLV, win.LVM_GETITEMRECT, idx, uintptr(unsafe.Pointer(&rc))) {
+		return tv.WidgetBase.ContextMenuLocation()
+	}
+	var pt win.POINT
+	if tv.RightToLeftReading() {
+		pt.X = rc.Right
+	} else {
+		pt.X = rc.Left
+	}
+	pt.X = rc.Bottom
+	win.ClientToScreen(tv.hwndNormalLV, &pt)
+	return Point{int(pt.X), int(pt.Y)}
+}
+
 // SortableByHeaderClick returns if the user can change sorting by clicking the header.
 func (tv *TableView) SortableByHeaderClick() bool {
 	return !hasWindowLongBits(tv.hwndFrozenLV, win.GWL_STYLE, win.LVS_NOSORTHEADER) ||

--- a/tableview.go
+++ b/tableview.go
@@ -539,6 +539,7 @@ func (tv *TableView) ContextMenuLocation() Point {
 		pt.X = rc.Left
 	}
 	pt.X = rc.Bottom
+	windowTrimToClientBounds(tv.hwndNormalLV, &pt)
 	win.ClientToScreen(tv.hwndNormalLV, &pt)
 	return Point{int(pt.X), int(pt.Y)}
 }

--- a/textedit.go
+++ b/textedit.go
@@ -273,6 +273,19 @@ func (te *TextEdit) SetTextColor(c Color) {
 	te.Invalidate()
 }
 
+// ContextMenuLocation returns carret position in screen coordinates.
+func (te *TextEdit) ContextMenuLocation() Point {
+	idx := int(te.SendMessage(win.EM_GETCARETINDEX, 0, 0))
+	if idx < 0 {
+		start, end := te.TextSelection()
+		idx = (start + end) / 2
+	}
+	res := uint32(te.SendMessage(win.EM_POSFROMCHAR, uintptr(idx), 0))
+	pt := win.POINT{int32(win.LOWORD(res)), int32(win.HIWORD(res))}
+	win.ClientToScreen(te.hWnd, &pt)
+	return Point{int(pt.X), int(pt.Y)}
+}
+
 func (*TextEdit) NeedsWmSize() bool {
 	return true
 }

--- a/textedit.go
+++ b/textedit.go
@@ -282,7 +282,7 @@ func (te *TextEdit) ContextMenuLocation() Point {
 	}
 	res := uint32(te.SendMessage(win.EM_POSFROMCHAR, uintptr(idx), 0))
 	pt := win.POINT{int32(win.LOWORD(res)), int32(win.HIWORD(res))}
-	win.ClientToScreen(te.hWnd, &pt)
+	windowTrimToClientBounds(te.hWnd, &pt)
 	return Point{int(pt.X), int(pt.Y)}
 }
 

--- a/window.go
+++ b/window.go
@@ -1711,6 +1711,28 @@ func (wb *WindowBase) SetHeightPixels(value int) error {
 	return wb.SetBoundsPixels(bounds)
 }
 
+func windowTrimToClientBounds(hwnd win.HWND, pt *win.POINT) {
+	var r win.RECT
+
+	if !win.GetClientRect(hwnd, &r) {
+		lastError("GetClientRect")
+		return
+	}
+
+	if pt.X < r.Left {
+		pt.X = r.Left
+	}
+	if pt.X > r.Right {
+		pt.X = r.Right
+	}
+	if pt.Y < r.Top {
+		pt.Y = r.Top
+	}
+	if pt.Y > r.Bottom {
+		pt.Y = r.Bottom
+	}
+}
+
 func windowClientBounds(hwnd win.HWND) Rectangle {
 	var r win.RECT
 


### PR DESCRIPTION
When user invokes context menu using keyboard (Shift+F10), the (X, Y) of the WM_CONTEXTMENU message are (-1, -1). Stock controls use their center to popup the context menu so should we. However, some controls may provide better location than this.

Requires: https://github.com/lxn/win/pull/91