### PR TITLE
Increased reliance on WindowGroup for data with thread affinity

### DIFF
--- a/application.go
+++ b/application.go
@@ -7,10 +7,9 @@
 package walk
 
 import (
+	"sync"
 	"time"
-)
 
-import (
 	"github.com/lxn/win"
 )
 
@@ -34,6 +33,7 @@ type Persistable interface {
 }
 
 type Application struct {
+	mutex              sync.RWMutex
 	organizationName   string
 	productName        string
 	settings           Settings
@@ -50,43 +50,63 @@ func App() *Application {
 }
 
 func (app *Application) OrganizationName() string {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.organizationName
 }
 
 func (app *Application) SetOrganizationName(value string) {
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
 	app.organizationName = value
 }
 
 func (app *Application) ProductName() string {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.productName
 }
 
 func (app *Application) SetProductName(value string) {
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
 	app.productName = value
 }
 
 func (app *Application) Settings() Settings {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.settings
 }
 
 func (app *Application) SetSettings(value Settings) {
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
 	app.settings = value
 }
 
 func (app *Application) Exit(exitCode int) {
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
 	app.exiting = true
 	app.exitCode = exitCode
 	win.PostQuitMessage(int32(exitCode))
 }
 
 func (app *Application) ExitCode() int {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.exitCode
 }
 
 func (app *Application) Panicking() *ErrorEvent {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.panickingPublisher.Event()
 }
 
 func (app *Application) ActiveForm() Form {
+	app.mutex.RLock()
+	defer app.mutex.RUnlock()
 	return app.activeForm
 }

--- a/application.go
+++ b/application.go
@@ -110,3 +110,9 @@ func (app *Application) ActiveForm() Form {
 	defer app.mutex.RUnlock()
 	return app.activeForm
 }
+
+func (app *Application) setActiveForm(form Form) {
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
+	app.activeForm = form
+}

--- a/databinding.go
+++ b/databinding.go
@@ -167,7 +167,7 @@ func (db *DataBinder) SetBoundWidgets(boundWidgets []Widget) {
 					if db.autoSubmitDelay > 0 {
 						if db.autoSubmitTimer == nil {
 							db.autoSubmitTimer = time.AfterFunc(db.autoSubmitDelay, func() {
-								synchronize(func() {
+								widget.Synchronize(func() {
 									db.Submit()
 								})
 							})

--- a/event.go
+++ b/event.go
@@ -37,7 +37,11 @@ func (p *EventPublisher) Event() *Event {
 }
 
 func (p *EventPublisher) Publish() {
-	if form := appSingleton.activeForm; form != nil {
+	// This is a kludge to find the form that the event publisher is
+	// affiliated with. It's only necessary because the event publisher
+	// doesn't keep a pointer to the form on its own, and the call
+	// to Publish isn't providing it either.
+	if form := App().ActiveForm(); form != nil {
 		fb := form.AsFormBase()
 		fb.inProgressEventCount++
 		defer func() {

--- a/form.go
+++ b/form.go
@@ -602,7 +602,7 @@ func (fb *FormBase) Hide() {
 func (fb *FormBase) Show() {
 	fb.proposedSize = maxSize(fb.minSize, fb.SizePixels())
 
-	if p, ok := fb.window.(Persistable); ok && p.Persistent() && appSingleton.settings != nil {
+	if p, ok := fb.window.(Persistable); ok && p.Persistent() && App().Settings() != nil {
 		p.RestoreState()
 	}
 
@@ -610,7 +610,7 @@ func (fb *FormBase) Show() {
 }
 
 func (fb *FormBase) close() error {
-	if p, ok := fb.window.(Persistable); ok && p.Persistent() && appSingleton.settings != nil {
+	if p, ok := fb.window.(Persistable); ok && p.Persistent() && App().Settings() != nil {
 		p.SaveState()
 	}
 
@@ -746,14 +746,14 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 				win.SetFocus(fb.prevFocusHWnd)
 			}
 
-			appSingleton.activeForm = fb.window.(Form)
+			App().setActiveForm(fb.window.(Form))
 
 			fb.activatingPublisher.Publish()
 
 		case win.WA_INACTIVE:
 			fb.prevFocusHWnd = win.GetFocus()
 
-			appSingleton.activeForm = nil
+			App().setActiveForm(nil)
 
 			fb.deactivatingPublisher.Publish()
 		}

--- a/inifilesettings.go
+++ b/inifilesettings.go
@@ -114,8 +114,8 @@ func (ifs *IniFileSettings) FilePath() string {
 
 	return filepath.Join(
 		appDataPath,
-		appSingleton.OrganizationName(),
-		appSingleton.ProductName(),
+		App().OrganizationName(),
+		App().ProductName(),
 		ifs.fileName)
 }
 

--- a/layout.go
+++ b/layout.go
@@ -133,7 +133,7 @@ func startLayoutPerformer(form Form) (performLayout chan ContainerLayoutItem, la
 				if sizing {
 					layoutResults <- results
 				} else {
-					synchronizeApplyLayoutResults(results, stopwatch)
+					form.AsFormBase().synchronizeLayout(results, stopwatch)
 				}
 
 			case sizing = <-inSizeLoop:

--- a/mainloop_cgo.go
+++ b/mainloop_cgo.go
@@ -35,7 +35,7 @@ import (
 //             TranslateMessage(&m);
 //             DispatchMessage(&m);
 //         }
-//         shimRunSynchronized();
+//         shimRunSynchronized(fb_ptr);
 //     }
 //     return 0;
 // }
@@ -47,8 +47,8 @@ func shimHandleKeyDown(fb uintptr, msg uintptr) bool {
 }
 
 //export shimRunSynchronized
-func shimRunSynchronized() {
-	runSynchronized()
+func shimRunSynchronized(fb uintptr) {
+	(*FormBase)(unsafe.Pointer(fb)).group.RunSynchronized()
 }
 
 func (fb *FormBase) mainLoop() int {

--- a/mainloop_default.go
+++ b/mainloop_default.go
@@ -7,8 +7,9 @@
 package walk
 
 import (
-	"github.com/lxn/win"
 	"unsafe"
+
+	"github.com/lxn/win"
 )
 
 func (fb *FormBase) mainLoop() int {
@@ -36,7 +37,7 @@ func (fb *FormBase) mainLoop() int {
 			win.DispatchMessage(msg)
 		}
 
-		runSynchronized()
+		fb.group.RunSynchronized()
 	}
 
 	return 0

--- a/window.go
+++ b/window.go
@@ -1983,7 +1983,7 @@ func (wb *WindowBase) RequestLayout() {
 		return
 	}
 
-	if fb := form.AsFormBase(); appSingleton.activeForm != form || fb.inProgressEventCount == 0 {
+	if fb := form.AsFormBase(); App().ActiveForm() != form || fb.inProgressEventCount == 0 {
 		fb.startLayout()
 	} else {
 		fb.layoutScheduled = true
@@ -2152,7 +2152,7 @@ func (wb *WindowBase) Synchronize(f func()) {
 }
 
 func (wb *WindowBase) ReadState() (string, error) {
-	settings := appSingleton.settings
+	settings := App().Settings()
 	if settings == nil {
 		return "", newError("App().Settings() must not be nil")
 	}
@@ -2162,7 +2162,7 @@ func (wb *WindowBase) ReadState() (string, error) {
 }
 
 func (wb *WindowBase) WriteState(state string) error {
-	settings := appSingleton.settings
+	settings := App().Settings()
 	if settings == nil {
 		return newError("App().Settings() must not be nil")
 	}
@@ -2188,7 +2188,9 @@ func windowFromHandle(hwnd win.HWND) Window {
 
 func defaultWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result uintptr) {
 	defer func() {
-		if len(appSingleton.panickingPublisher.event.handlers) > 0 {
+		// FIXME: Rework the panicking publisher so that we don't have to
+		// access a private member here.
+		if len(App().panickingPublisher.event.handlers) > 0 {
 			var err error
 			if x := recover(); x != nil {
 				if e, ok := x.(error); ok {
@@ -2198,7 +2200,7 @@ func defaultWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result u
 				}
 			}
 			if err != nil {
-				appSingleton.panickingPublisher.Publish(err)
+				App().panickingPublisher.Publish(err)
 			}
 		}
 	}()
@@ -2455,7 +2457,7 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 				}
 			}
 
-			if wb.Form() == appSingleton.ActiveForm() {
+			if wb.Form() == App().ActiveForm() {
 				wnd.AsWidgetBase().invalidateBorderInParent()
 			}
 		}


### PR DESCRIPTION
Partial implementation of https://github.com/lxn/walk/issues/619

* Members of `Application` are now guarded by a mutex
* Replaced direct access to `appSingleton` with calls to `App()`
* Moved active form management to `WindowGroup`
* Moved per-thread function synchronization to `WindowGroup`
* The window group manager now has distinct `Group()` and `CreateGroup()` methods

This pull request doesn't deal with window class registration, which will eventually need to be handled by `WindowGroup` to complete #619. That will be a very significant change to walk's initialization with potential for merge conflicts, so I think that should be kept separate and can go in a later PR.