### PR TITLE
Dynamic Annotation Cleanup

### DIFF
--- a/accessibility.go
+++ b/accessibility.go
@@ -182,7 +182,7 @@ func (a *Accessibility) SetValueMap(valueMap string) error {
 // accSetPropertyInt sets integer window property for Dynamic Annotation.
 func (a *Accessibility) accSetPropertyInt(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value int32) error {
 	accPropServices := a.wb.group.accessibilityServices()
-	if accPropServices != nil {
+	if accPropServices == nil {
 		return newError("Dynamic Annotation not available")
 	}
 	var v win.VARIANT
@@ -200,7 +200,7 @@ func (a *Accessibility) accSetPropertyInt(hwnd win.HWND, idProp *win.MSAAPROPID,
 // accSetPropertyStr sets string window property for Dynamic Annotation.
 func (a *Accessibility) accSetPropertyStr(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value string) error {
 	accPropServices := a.wb.group.accessibilityServices()
-	if accPropServices != nil {
+	if accPropServices == nil {
 		return newError("Dynamic Annotation not available")
 	}
 	hr := accPropServices.SetHwndPropStr(hwnd, win.OBJID_CLIENT, win.CHILDID_SELF, idProp, value)

--- a/accessibility.go
+++ b/accessibility.go
@@ -8,8 +8,10 @@ package walk
 
 import "github.com/lxn/win"
 
+// AccState enum defines the state of the window/control
 type AccState int32
 
+// Window/control states
 const (
 	AccStateNormal          AccState = win.STATE_SYSTEM_NORMAL
 	AccStateUnavailable     AccState = win.STATE_SYSTEM_UNAVAILABLE
@@ -47,8 +49,10 @@ const (
 	AccStateValid           AccState = win.STATE_SYSTEM_VALID
 )
 
+// AccRole enum defines the role of the window/control in UI.
 type AccRole int32
 
+// Window/control system roles
 const (
 	AccRoleTitlebar           AccRole = win.ROLE_SYSTEM_TITLEBAR
 	AccRoleMenubar            AccRole = win.ROLE_SYSTEM_MENUBAR
@@ -116,6 +120,7 @@ const (
 	AccRoleOutlineButton      AccRole = win.ROLE_SYSTEM_OUTLINEBUTTON
 )
 
+// Accessibility provides basic Dynamic Annotation of windows and controls.
 type Accessibility struct {
 	wb *WindowBase
 }

--- a/accessibility.go
+++ b/accessibility.go
@@ -115,3 +115,95 @@ const (
 	AccRoleIPAddress          AccRole = win.ROLE_SYSTEM_IPADDRESS
 	AccRoleOutlineButton      AccRole = win.ROLE_SYSTEM_OUTLINEBUTTON
 )
+
+type Accessibility struct {
+	wb *WindowBase
+}
+
+// SetAccelerator sets window accelerator name using Dynamic Annotation.
+func (a *Accessibility) SetAccelerator(acc string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_KEYBOARDSHORTCUT, win.EVENT_OBJECT_ACCELERATORCHANGE, acc)
+}
+
+// SetDefaultAction sets window default action using Dynamic Annotation.
+func (a *Accessibility) SetDefaultAction(defAction string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_DEFAULTACTION, win.EVENT_OBJECT_DEFACTIONCHANGE, defAction)
+}
+
+// SetDescription sets window description using Dynamic Annotation.
+func (a *Accessibility) SetDescription(acc string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_DESCRIPTION, win.EVENT_OBJECT_DESCRIPTIONCHANGE, acc)
+}
+
+// SetHelp sets window help using Dynamic Annotation.
+func (a *Accessibility) SetHelp(help string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_HELP, win.EVENT_OBJECT_HELPCHANGE, help)
+}
+
+// SetName sets window name using Dynamic Annotation.
+func (a *Accessibility) SetName(name string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_NAME, win.EVENT_OBJECT_NAMECHANGE, name)
+}
+
+// SetRole sets window role using Dynamic Annotation. The role must be set when the window is
+// created and is not to be modified later.
+func (a *Accessibility) SetRole(role AccRole) error {
+	return a.accSetPropertyInt(a.wb.hWnd, &win.PROPID_ACC_ROLE, 0, int32(role))
+}
+
+// SetRoleMap sets window role map using Dynamic Annotation. The role map must be set when the
+// window is created and is not to be modified later.
+func (a *Accessibility) SetRoleMap(roleMap string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_ROLEMAP, 0, roleMap)
+}
+
+// SetState sets window state using Dynamic Annotation.
+func (a *Accessibility) SetState(state AccState) error {
+	return a.accSetPropertyInt(a.wb.hWnd, &win.PROPID_ACC_STATE, win.EVENT_OBJECT_STATECHANGE, int32(state))
+}
+
+// SetStateMap sets window state map using Dynamic Annotation. The state map must be set when
+// the window is created and is not to be modified later.
+func (a *Accessibility) SetStateMap(stateMap string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_STATEMAP, 0, stateMap)
+}
+
+// SetValueMap sets window value map using Dynamic Annotation. The value map must be set when
+// the window is created and is not to be modified later.
+func (a *Accessibility) SetValueMap(valueMap string) error {
+	return a.accSetPropertyStr(a.wb.hWnd, &win.PROPID_ACC_VALUEMAP, 0, valueMap)
+}
+
+// accSetPropertyInt sets integer window property for Dynamic Annotation.
+func (a *Accessibility) accSetPropertyInt(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value int32) error {
+	accPropServices := a.wb.group.accessibilityServices()
+	if accPropServices != nil {
+		return newError("Dynamic Annotation not available")
+	}
+	var v win.VARIANT
+	v.SetLong(value)
+	hr := accPropServices.SetHwndProp(hwnd, win.OBJID_CLIENT, win.CHILDID_SELF, idProp, &v)
+	if win.FAILED(hr) {
+		return errorFromHRESULT("IAccPropServices.SetHwndProp", hr)
+	}
+	if win.EVENT_OBJECT_CREATE <= event && event <= win.EVENT_OBJECT_END {
+		win.NotifyWinEvent(event, hwnd, win.OBJID_CLIENT, win.CHILDID_SELF)
+	}
+	return nil
+}
+
+// accSetPropertyStr sets string window property for Dynamic Annotation.
+func (a *Accessibility) accSetPropertyStr(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value string) error {
+	accPropServices := a.wb.group.accessibilityServices()
+	if accPropServices != nil {
+		return newError("Dynamic Annotation not available")
+	}
+	hr := accPropServices.SetHwndPropStr(hwnd, win.OBJID_CLIENT, win.CHILDID_SELF, idProp, value)
+	if win.FAILED(hr) {
+		return errorFromHRESULT("IAccPropServices.SetHwndPropStr", hr)
+	}
+	if win.EVENT_OBJECT_CREATE <= event && event <= win.EVENT_OBJECT_END {
+		win.NotifyWinEvent(event, hwnd, win.OBJID_CLIENT, win.CHILDID_SELF)
+	}
+	return nil
+}

--- a/accessibility.go
+++ b/accessibility.go
@@ -1,0 +1,117 @@
+// Copyright 2010 The Walk Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package walk
+
+import "github.com/lxn/win"
+
+type AccState int32
+
+const (
+	AccStateNormal          AccState = win.STATE_SYSTEM_NORMAL
+	AccStateUnavailable     AccState = win.STATE_SYSTEM_UNAVAILABLE
+	AccStateSelected        AccState = win.STATE_SYSTEM_SELECTED
+	AccStateFocused         AccState = win.STATE_SYSTEM_FOCUSED
+	AccStatePressed         AccState = win.STATE_SYSTEM_PRESSED
+	AccStateChecked         AccState = win.STATE_SYSTEM_CHECKED
+	AccStateMixed           AccState = win.STATE_SYSTEM_MIXED
+	AccStateIndeterminate   AccState = win.STATE_SYSTEM_INDETERMINATE
+	AccStateReadonly        AccState = win.STATE_SYSTEM_READONLY
+	AccStateHotTracked      AccState = win.STATE_SYSTEM_HOTTRACKED
+	AccStateDefault         AccState = win.STATE_SYSTEM_DEFAULT
+	AccStateExpanded        AccState = win.STATE_SYSTEM_EXPANDED
+	AccStateCollapsed       AccState = win.STATE_SYSTEM_COLLAPSED
+	AccStateBusy            AccState = win.STATE_SYSTEM_BUSY
+	AccStateFloating        AccState = win.STATE_SYSTEM_FLOATING
+	AccStateMarqueed        AccState = win.STATE_SYSTEM_MARQUEED
+	AccStateAnimated        AccState = win.STATE_SYSTEM_ANIMATED
+	AccStateInvisible       AccState = win.STATE_SYSTEM_INVISIBLE
+	AccStateOffscreen       AccState = win.STATE_SYSTEM_OFFSCREEN
+	AccStateSizeable        AccState = win.STATE_SYSTEM_SIZEABLE
+	AccStateMoveable        AccState = win.STATE_SYSTEM_MOVEABLE
+	AccStateSelfVoicing     AccState = win.STATE_SYSTEM_SELFVOICING
+	AccStateFocusable       AccState = win.STATE_SYSTEM_FOCUSABLE
+	AccStateSelectable      AccState = win.STATE_SYSTEM_SELECTABLE
+	AccStateLinked          AccState = win.STATE_SYSTEM_LINKED
+	AccStateTraversed       AccState = win.STATE_SYSTEM_TRAVERSED
+	AccStateMultiselectable AccState = win.STATE_SYSTEM_MULTISELECTABLE
+	AccStateExtselectable   AccState = win.STATE_SYSTEM_EXTSELECTABLE
+	AccStateAlertLow        AccState = win.STATE_SYSTEM_ALERT_LOW
+	AccStateAlertMedium     AccState = win.STATE_SYSTEM_ALERT_MEDIUM
+	AccStateAlertHigh       AccState = win.STATE_SYSTEM_ALERT_HIGH
+	AccStateProtected       AccState = win.STATE_SYSTEM_PROTECTED
+	AccStateHasPopup        AccState = win.STATE_SYSTEM_HASPOPUP
+	AccStateValid           AccState = win.STATE_SYSTEM_VALID
+)
+
+type AccRole int32
+
+const (
+	AccRoleTitlebar           AccRole = win.ROLE_SYSTEM_TITLEBAR
+	AccRoleMenubar            AccRole = win.ROLE_SYSTEM_MENUBAR
+	AccRoleScrollbar          AccRole = win.ROLE_SYSTEM_SCROLLBAR
+	AccRoleGrip               AccRole = win.ROLE_SYSTEM_GRIP
+	AccRoleSound              AccRole = win.ROLE_SYSTEM_SOUND
+	AccRoleCursor             AccRole = win.ROLE_SYSTEM_CURSOR
+	AccRoleCaret              AccRole = win.ROLE_SYSTEM_CARET
+	AccRoleAlert              AccRole = win.ROLE_SYSTEM_ALERT
+	AccRoleWindow             AccRole = win.ROLE_SYSTEM_WINDOW
+	AccRoleClient             AccRole = win.ROLE_SYSTEM_CLIENT
+	AccRoleMenuPopup          AccRole = win.ROLE_SYSTEM_MENUPOPUP
+	AccRoleMenuItem           AccRole = win.ROLE_SYSTEM_MENUITEM
+	AccRoleTooltip            AccRole = win.ROLE_SYSTEM_TOOLTIP
+	AccRoleApplication        AccRole = win.ROLE_SYSTEM_APPLICATION
+	AccRoleDocument           AccRole = win.ROLE_SYSTEM_DOCUMENT
+	AccRolePane               AccRole = win.ROLE_SYSTEM_PANE
+	AccRoleChart              AccRole = win.ROLE_SYSTEM_CHART
+	AccRoleDialog             AccRole = win.ROLE_SYSTEM_DIALOG
+	AccRoleBorder             AccRole = win.ROLE_SYSTEM_BORDER
+	AccRoleGrouping           AccRole = win.ROLE_SYSTEM_GROUPING
+	AccRoleSeparator          AccRole = win.ROLE_SYSTEM_SEPARATOR
+	AccRoleToolbar            AccRole = win.ROLE_SYSTEM_TOOLBAR
+	AccRoleStatusbar          AccRole = win.ROLE_SYSTEM_STATUSBAR
+	AccRoleTable              AccRole = win.ROLE_SYSTEM_TABLE
+	AccRoleColumnHeader       AccRole = win.ROLE_SYSTEM_COLUMNHEADER
+	AccRoleRowHeader          AccRole = win.ROLE_SYSTEM_ROWHEADER
+	AccRoleColumn             AccRole = win.ROLE_SYSTEM_COLUMN
+	AccRoleRow                AccRole = win.ROLE_SYSTEM_ROW
+	AccRoleCell               AccRole = win.ROLE_SYSTEM_CELL
+	AccRoleLink               AccRole = win.ROLE_SYSTEM_LINK
+	AccRoleHelpBalloon        AccRole = win.ROLE_SYSTEM_HELPBALLOON
+	AccRoleCharacter          AccRole = win.ROLE_SYSTEM_CHARACTER
+	AccRoleList               AccRole = win.ROLE_SYSTEM_LIST
+	AccRoleListItem           AccRole = win.ROLE_SYSTEM_LISTITEM
+	AccRoleOutline            AccRole = win.ROLE_SYSTEM_OUTLINE
+	AccRoleOutlineItem        AccRole = win.ROLE_SYSTEM_OUTLINEITEM
+	AccRolePagetab            AccRole = win.ROLE_SYSTEM_PAGETAB
+	AccRolePropertyPage       AccRole = win.ROLE_SYSTEM_PROPERTYPAGE
+	AccRoleIndicator          AccRole = win.ROLE_SYSTEM_INDICATOR
+	AccRoleGraphic            AccRole = win.ROLE_SYSTEM_GRAPHIC
+	AccRoleStatictext         AccRole = win.ROLE_SYSTEM_STATICTEXT
+	AccRoleText               AccRole = win.ROLE_SYSTEM_TEXT
+	AccRolePushbutton         AccRole = win.ROLE_SYSTEM_PUSHBUTTON
+	AccRoleCheckbutton        AccRole = win.ROLE_SYSTEM_CHECKBUTTON
+	AccRoleRadiobutton        AccRole = win.ROLE_SYSTEM_RADIOBUTTON
+	AccRoleCombobox           AccRole = win.ROLE_SYSTEM_COMBOBOX
+	AccRoleDroplist           AccRole = win.ROLE_SYSTEM_DROPLIST
+	AccRoleProgressbar        AccRole = win.ROLE_SYSTEM_PROGRESSBAR
+	AccRoleDial               AccRole = win.ROLE_SYSTEM_DIAL
+	AccRoleHotkeyfield        AccRole = win.ROLE_SYSTEM_HOTKEYFIELD
+	AccRoleSlider             AccRole = win.ROLE_SYSTEM_SLIDER
+	AccRoleSpinbutton         AccRole = win.ROLE_SYSTEM_SPINBUTTON
+	AccRoleDiagram            AccRole = win.ROLE_SYSTEM_DIAGRAM
+	AccRoleAnimation          AccRole = win.ROLE_SYSTEM_ANIMATION
+	AccRoleEquation           AccRole = win.ROLE_SYSTEM_EQUATION
+	AccRoleButtonDropdown     AccRole = win.ROLE_SYSTEM_BUTTONDROPDOWN
+	AccRoleButtonMenu         AccRole = win.ROLE_SYSTEM_BUTTONMENU
+	AccRoleButtonDropdownGrid AccRole = win.ROLE_SYSTEM_BUTTONDROPDOWNGRID
+	AccRoleWhitespace         AccRole = win.ROLE_SYSTEM_WHITESPACE
+	AccRolePageTabList        AccRole = win.ROLE_SYSTEM_PAGETABLIST
+	AccRoleClock              AccRole = win.ROLE_SYSTEM_CLOCK
+	AccRoleSplitButton        AccRole = win.ROLE_SYSTEM_SPLITBUTTON
+	AccRoleIPAddress          AccRole = win.ROLE_SYSTEM_IPADDRESS
+	AccRoleOutlineButton      AccRole = win.ROLE_SYSTEM_OUTLINEBUTTON
+)

--- a/declarative/accessibility.go
+++ b/declarative/accessibility.go
@@ -1,0 +1,137 @@
+// Copyright 2012 The Walk Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package declarative
+
+import (
+	"github.com/lxn/walk"
+)
+
+// AccState enum defines the state of the window/control
+type AccState int32
+
+// Window/control states
+const (
+	AccStateNormal          = AccState(walk.AccStateNormal)
+	AccStateUnavailable     = AccState(walk.AccStateUnavailable)
+	AccStateSelected        = AccState(walk.AccStateSelected)
+	AccStateFocused         = AccState(walk.AccStateFocused)
+	AccStatePressed         = AccState(walk.AccStatePressed)
+	AccStateChecked         = AccState(walk.AccStateChecked)
+	AccStateMixed           = AccState(walk.AccStateMixed)
+	AccStateIndeterminate   = AccState(walk.AccStateIndeterminate)
+	AccStateReadonly        = AccState(walk.AccStateReadonly)
+	AccStateHotTracked      = AccState(walk.AccStateHotTracked)
+	AccStateDefault         = AccState(walk.AccStateDefault)
+	AccStateExpanded        = AccState(walk.AccStateExpanded)
+	AccStateCollapsed       = AccState(walk.AccStateCollapsed)
+	AccStateBusy            = AccState(walk.AccStateBusy)
+	AccStateFloating        = AccState(walk.AccStateFloating)
+	AccStateMarqueed        = AccState(walk.AccStateMarqueed)
+	AccStateAnimated        = AccState(walk.AccStateAnimated)
+	AccStateInvisible       = AccState(walk.AccStateInvisible)
+	AccStateOffscreen       = AccState(walk.AccStateOffscreen)
+	AccStateSizeable        = AccState(walk.AccStateSizeable)
+	AccStateMoveable        = AccState(walk.AccStateMoveable)
+	AccStateSelfVoicing     = AccState(walk.AccStateSelfVoicing)
+	AccStateFocusable       = AccState(walk.AccStateFocusable)
+	AccStateSelectable      = AccState(walk.AccStateSelectable)
+	AccStateLinked          = AccState(walk.AccStateLinked)
+	AccStateTraversed       = AccState(walk.AccStateTraversed)
+	AccStateMultiselectable = AccState(walk.AccStateMultiselectable)
+	AccStateExtselectable   = AccState(walk.AccStateExtselectable)
+	AccStateAlertLow        = AccState(walk.AccStateAlertLow)
+	AccStateAlertMedium     = AccState(walk.AccStateAlertMedium)
+	AccStateAlertHigh       = AccState(walk.AccStateAlertHigh)
+	AccStateProtected       = AccState(walk.AccStateProtected)
+	AccStateHasPopup        = AccState(walk.AccStateHasPopup)
+	AccStateValid           = AccState(walk.AccStateValid)
+)
+
+// AccRole enum defines the role of the window/control in UI.
+type AccRole int32
+
+// Window/control system roles
+const (
+	AccRoleTitlebar           = AccRole(walk.AccRoleTitlebar)
+	AccRoleMenubar            = AccRole(walk.AccRoleMenubar)
+	AccRoleScrollbar          = AccRole(walk.AccRoleScrollbar)
+	AccRoleGrip               = AccRole(walk.AccRoleGrip)
+	AccRoleSound              = AccRole(walk.AccRoleSound)
+	AccRoleCursor             = AccRole(walk.AccRoleCursor)
+	AccRoleCaret              = AccRole(walk.AccRoleCaret)
+	AccRoleAlert              = AccRole(walk.AccRoleAlert)
+	AccRoleWindow             = AccRole(walk.AccRoleWindow)
+	AccRoleClient             = AccRole(walk.AccRoleClient)
+	AccRoleMenuPopup          = AccRole(walk.AccRoleMenuPopup)
+	AccRoleMenuItem           = AccRole(walk.AccRoleMenuItem)
+	AccRoleTooltip            = AccRole(walk.AccRoleTooltip)
+	AccRoleApplication        = AccRole(walk.AccRoleApplication)
+	AccRoleDocument           = AccRole(walk.AccRoleDocument)
+	AccRolePane               = AccRole(walk.AccRolePane)
+	AccRoleChart              = AccRole(walk.AccRoleChart)
+	AccRoleDialog             = AccRole(walk.AccRoleDialog)
+	AccRoleBorder             = AccRole(walk.AccRoleBorder)
+	AccRoleGrouping           = AccRole(walk.AccRoleGrouping)
+	AccRoleSeparator          = AccRole(walk.AccRoleSeparator)
+	AccRoleToolbar            = AccRole(walk.AccRoleToolbar)
+	AccRoleStatusbar          = AccRole(walk.AccRoleStatusbar)
+	AccRoleTable              = AccRole(walk.AccRoleTable)
+	AccRoleColumnHeader       = AccRole(walk.AccRoleColumnHeader)
+	AccRoleRowHeader          = AccRole(walk.AccRoleRowHeader)
+	AccRoleColumn             = AccRole(walk.AccRoleColumn)
+	AccRoleRow                = AccRole(walk.AccRoleRow)
+	AccRoleCell               = AccRole(walk.AccRoleCell)
+	AccRoleLink               = AccRole(walk.AccRoleLink)
+	AccRoleHelpBalloon        = AccRole(walk.AccRoleHelpBalloon)
+	AccRoleCharacter          = AccRole(walk.AccRoleCharacter)
+	AccRoleList               = AccRole(walk.AccRoleList)
+	AccRoleListItem           = AccRole(walk.AccRoleListItem)
+	AccRoleOutline            = AccRole(walk.AccRoleOutline)
+	AccRoleOutlineItem        = AccRole(walk.AccRoleOutlineItem)
+	AccRolePagetab            = AccRole(walk.AccRolePagetab)
+	AccRolePropertyPage       = AccRole(walk.AccRolePropertyPage)
+	AccRoleIndicator          = AccRole(walk.AccRoleIndicator)
+	AccRoleGraphic            = AccRole(walk.AccRoleGraphic)
+	AccRoleStatictext         = AccRole(walk.AccRoleStatictext)
+	AccRoleText               = AccRole(walk.AccRoleText)
+	AccRolePushbutton         = AccRole(walk.AccRolePushbutton)
+	AccRoleCheckbutton        = AccRole(walk.AccRoleCheckbutton)
+	AccRoleRadiobutton        = AccRole(walk.AccRoleRadiobutton)
+	AccRoleCombobox           = AccRole(walk.AccRoleCombobox)
+	AccRoleDroplist           = AccRole(walk.AccRoleDroplist)
+	AccRoleProgressbar        = AccRole(walk.AccRoleProgressbar)
+	AccRoleDial               = AccRole(walk.AccRoleDial)
+	AccRoleHotkeyfield        = AccRole(walk.AccRoleHotkeyfield)
+	AccRoleSlider             = AccRole(walk.AccRoleSlider)
+	AccRoleSpinbutton         = AccRole(walk.AccRoleSpinbutton)
+	AccRoleDiagram            = AccRole(walk.AccRoleDiagram)
+	AccRoleAnimation          = AccRole(walk.AccRoleAnimation)
+	AccRoleEquation           = AccRole(walk.AccRoleEquation)
+	AccRoleButtonDropdown     = AccRole(walk.AccRoleButtonDropdown)
+	AccRoleButtonMenu         = AccRole(walk.AccRoleButtonMenu)
+	AccRoleButtonDropdownGrid = AccRole(walk.AccRoleButtonDropdownGrid)
+	AccRoleWhitespace         = AccRole(walk.AccRoleWhitespace)
+	AccRolePageTabList        = AccRole(walk.AccRolePageTabList)
+	AccRoleClock              = AccRole(walk.AccRoleClock)
+	AccRoleSplitButton        = AccRole(walk.AccRoleSplitButton)
+	AccRoleIPAddress          = AccRole(walk.AccRoleIPAddress)
+	AccRoleOutlineButton      = AccRole(walk.AccRoleOutlineButton)
+)
+
+// Accessibility properties
+type Accessibility struct {
+	Accelerator   Property
+	DefaultAction Property
+	Description   Property
+	Help          Property
+	Name          Property
+	Role          Property
+	RoleMap       Property
+	State         Property
+	StateMap      Property
+	ValueMap      Property
+}

--- a/declarative/accessibility.go
+++ b/declarative/accessibility.go
@@ -124,14 +124,14 @@ const (
 
 // Accessibility properties
 type Accessibility struct {
-	Accelerator   Property
-	DefaultAction Property
-	Description   Property
-	Help          Property
-	Name          Property
-	Role          Property
-	RoleMap       Property
-	State         Property
-	StateMap      Property
-	ValueMap      Property
+	Accelerator   string
+	DefaultAction string
+	Description   string
+	Help          string
+	Name          string
+	Role          AccRole
+	RoleMap       string
+	State         AccState
+	StateMap      string
+	ValueMap      string
 }

--- a/declarative/builder.go
+++ b/declarative/builder.go
@@ -456,44 +456,44 @@ func (b *Builder) initAccessibility(d Widget, w walk.Window) error {
 	if accessibility.IsValid() {
 		a := accessibility.Interface().(Accessibility)
 
-		if value, ok := a.Accelerator.(string); ok {
-			w.Accessibility().SetAccelerator(value)
+		if a.Accelerator != "" {
+			w.Accessibility().SetAccelerator(a.Accelerator)
 		}
 
-		if value, ok := a.DefaultAction.(string); ok {
-			w.Accessibility().SetDefaultAction(value)
+		if a.DefaultAction != "" {
+			w.Accessibility().SetDefaultAction(a.DefaultAction)
 		}
 
-		if value, ok := a.Description.(string); ok {
-			w.Accessibility().SetDescription(value)
+		if a.Description != "" {
+			w.Accessibility().SetDescription(a.Description)
 		}
 
-		if value, ok := a.Help.(string); ok {
-			w.Accessibility().SetHelp(value)
+		if a.Help != "" {
+			w.Accessibility().SetHelp(a.Help)
 		}
 
-		if value, ok := a.Name.(string); ok {
-			w.Accessibility().SetName(value)
+		if a.Name != "" {
+			w.Accessibility().SetName(a.Name)
 		}
 
-		if value, ok := a.Role.(AccRole); ok {
-			w.Accessibility().SetRole(walk.AccRole(value))
+		if a.Role > 0 {
+			w.Accessibility().SetRole(walk.AccRole(a.Role))
 		}
 
-		if value, ok := a.RoleMap.(string); ok {
-			w.Accessibility().SetRoleMap(value)
+		if a.RoleMap != "" {
+			w.Accessibility().SetRoleMap(a.RoleMap)
 		}
 
-		if value, ok := a.State.(AccState); ok {
-			w.Accessibility().SetState(walk.AccState(value))
+		if a.State > 0 {
+			w.Accessibility().SetState(walk.AccState(a.State))
 		}
 
-		if value, ok := a.StateMap.(string); ok {
-			w.Accessibility().SetStateMap(value)
+		if a.StateMap != "" {
+			w.Accessibility().SetStateMap(a.StateMap)
 		}
 
-		if value, ok := a.ValueMap.(string); ok {
-			w.Accessibility().SetValueMap(value)
+		if a.ValueMap != "" {
+			w.Accessibility().SetValueMap(a.ValueMap)
 		}
 	}
 

--- a/declarative/builder.go
+++ b/declarative/builder.go
@@ -144,6 +144,9 @@ func (b *Builder) InitWidget(d Widget, w walk.Window, customInit func() error) e
 
 	b.declWidgets = append(b.declWidgets, declWidget{d, w})
 
+	// Window
+	b.initAccessibility(d, w)
+
 	// Widget
 	if name := b.string("Name"); name != "" {
 		w.SetName(name)
@@ -443,6 +446,56 @@ func (b *Builder) InitWidget(d Widget, w walk.Window, customInit func() error) e
 	}
 
 	succeeded = true
+
+	return nil
+}
+
+func (b *Builder) initAccessibility(d Widget, w walk.Window) error {
+	accessibility := b.widgetValue.FieldByName("Accessibility")
+
+	if accessibility.IsValid() {
+		a := accessibility.Interface().(Accessibility)
+
+		if value, ok := a.Accelerator.(string); ok {
+			w.Accessibility().SetAccelerator(value)
+		}
+
+		if value, ok := a.DefaultAction.(string); ok {
+			w.Accessibility().SetDefaultAction(value)
+		}
+
+		if value, ok := a.Description.(string); ok {
+			w.Accessibility().SetDescription(value)
+		}
+
+		if value, ok := a.Help.(string); ok {
+			w.Accessibility().SetHelp(value)
+		}
+
+		if value, ok := a.Name.(string); ok {
+			w.Accessibility().SetName(value)
+		}
+
+		if value, ok := a.Role.(AccRole); ok {
+			w.Accessibility().SetRole(walk.AccRole(value))
+		}
+
+		if value, ok := a.RoleMap.(string); ok {
+			w.Accessibility().SetRoleMap(value)
+		}
+
+		if value, ok := a.State.(AccState); ok {
+			w.Accessibility().SetState(walk.AccState(value))
+		}
+
+		if value, ok := a.StateMap.(string); ok {
+			w.Accessibility().SetStateMap(value)
+		}
+
+		if value, ok := a.ValueMap.(string); ok {
+			w.Accessibility().SetValueMap(value)
+		}
+	}
 
 	return nil
 }

--- a/declarative/checkbox.go
+++ b/declarative/checkbox.go
@@ -33,6 +33,7 @@ type CheckBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/checkbox.go
+++ b/declarative/checkbox.go
@@ -13,6 +13,7 @@ import (
 type CheckBox struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type CheckBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/combobox.go
+++ b/declarative/combobox.go
@@ -37,6 +37,7 @@ type ComboBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/combobox.go
+++ b/declarative/combobox.go
@@ -17,6 +17,7 @@ import (
 type ComboBox struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -37,7 +38,6 @@ type ComboBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/composite.go
+++ b/declarative/composite.go
@@ -14,6 +14,7 @@ import (
 type Composite struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -34,7 +35,6 @@ type Composite struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/composite.go
+++ b/declarative/composite.go
@@ -34,6 +34,7 @@ type Composite struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/customwidget.go
+++ b/declarative/customwidget.go
@@ -41,6 +41,7 @@ type CustomWidget struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/customwidget.go
+++ b/declarative/customwidget.go
@@ -21,6 +21,7 @@ const (
 type CustomWidget struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -41,7 +42,6 @@ type CustomWidget struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/dateedit.go
+++ b/declarative/dateedit.go
@@ -17,6 +17,7 @@ import (
 type DateEdit struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -37,7 +38,6 @@ type DateEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/dateedit.go
+++ b/declarative/dateedit.go
@@ -37,6 +37,7 @@ type DateEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/datelabel.go
+++ b/declarative/datelabel.go
@@ -33,6 +33,7 @@ type DateLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/datelabel.go
+++ b/declarative/datelabel.go
@@ -13,6 +13,7 @@ import (
 type DateLabel struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type DateLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/dialog.go
+++ b/declarative/dialog.go
@@ -13,6 +13,7 @@ import (
 type Dialog struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -34,7 +35,6 @@ type Dialog struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Container
 

--- a/declarative/dialog.go
+++ b/declarative/dialog.go
@@ -34,6 +34,7 @@ type Dialog struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Container
 
@@ -95,6 +96,7 @@ func (d Dialog) Create(owner walk.Form) error {
 		RightToLeftReading: d.RightToLeftReading,
 		ToolTipText:        "",
 		Visible:            d.Visible,
+		Accessibility:      d.Accessibility,
 
 		// Container
 		Children:   d.Children,

--- a/declarative/gradientcomposite.go
+++ b/declarative/gradientcomposite.go
@@ -34,6 +34,7 @@ type GradientComposite struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/gradientcomposite.go
+++ b/declarative/gradientcomposite.go
@@ -14,6 +14,7 @@ import (
 type GradientComposite struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -34,7 +35,6 @@ type GradientComposite struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/groupbox.go
+++ b/declarative/groupbox.go
@@ -13,6 +13,7 @@ import (
 type GroupBox struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type GroupBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/groupbox.go
+++ b/declarative/groupbox.go
@@ -33,6 +33,7 @@ type GroupBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/imageview.go
+++ b/declarative/imageview.go
@@ -44,6 +44,7 @@ type ImageView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/imageview.go
+++ b/declarative/imageview.go
@@ -24,6 +24,7 @@ const (
 type ImageView struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -44,7 +45,6 @@ type ImageView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/interfaces.go
+++ b/declarative/interfaces.go
@@ -118,6 +118,7 @@ func (ToolTipErrorPresenter) Create() (walk.ErrorPresenter, error) {
 type formInfo struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -137,7 +138,6 @@ type formInfo struct {
 	RightToLeftReading bool
 	ToolTipText        string
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Container
 

--- a/declarative/interfaces.go
+++ b/declarative/interfaces.go
@@ -137,6 +137,7 @@ type formInfo struct {
 	RightToLeftReading bool
 	ToolTipText        string
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Container
 

--- a/declarative/label.go
+++ b/declarative/label.go
@@ -33,6 +33,7 @@ type Label struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/label.go
+++ b/declarative/label.go
@@ -13,6 +13,7 @@ import (
 type Label struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type Label struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/lineedit.go
+++ b/declarative/lineedit.go
@@ -41,6 +41,7 @@ type LineEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/lineedit.go
+++ b/declarative/lineedit.go
@@ -21,6 +21,7 @@ const (
 type LineEdit struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -41,7 +42,6 @@ type LineEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/linklabel.go
+++ b/declarative/linklabel.go
@@ -13,6 +13,7 @@ import (
 type LinkLabel struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type LinkLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/linklabel.go
+++ b/declarative/linklabel.go
@@ -33,6 +33,7 @@ type LinkLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/listbox.go
+++ b/declarative/listbox.go
@@ -18,6 +18,7 @@ import (
 type ListBox struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -38,7 +39,6 @@ type ListBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/listbox.go
+++ b/declarative/listbox.go
@@ -38,6 +38,7 @@ type ListBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/mainwindow.go
+++ b/declarative/mainwindow.go
@@ -11,6 +11,7 @@ import "github.com/lxn/walk"
 type MainWindow struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -32,7 +33,6 @@ type MainWindow struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Container
 

--- a/declarative/mainwindow.go
+++ b/declarative/mainwindow.go
@@ -32,6 +32,7 @@ type MainWindow struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Container
 
@@ -88,6 +89,7 @@ func (mw MainWindow) Create() error {
 		OnSizeChanged:      mw.OnSizeChanged,
 		RightToLeftReading: mw.RightToLeftReading,
 		Visible:            mw.Visible,
+		Accessibility:      mw.Accessibility,
 
 		// Container
 		Children:   mw.Children,

--- a/declarative/numberedit.go
+++ b/declarative/numberedit.go
@@ -33,6 +33,7 @@ type NumberEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/numberedit.go
+++ b/declarative/numberedit.go
@@ -13,6 +13,7 @@ import (
 type NumberEdit struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type NumberEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/numberlabel.go
+++ b/declarative/numberlabel.go
@@ -13,6 +13,7 @@ import (
 type NumberLabel struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type NumberLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/numberlabel.go
+++ b/declarative/numberlabel.go
@@ -33,6 +33,7 @@ type NumberLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/progressbar.go
+++ b/declarative/progressbar.go
@@ -33,6 +33,7 @@ type ProgressBar struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/progressbar.go
+++ b/declarative/progressbar.go
@@ -13,6 +13,7 @@ import (
 type ProgressBar struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type ProgressBar struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/pushbutton.go
+++ b/declarative/pushbutton.go
@@ -33,6 +33,7 @@ type PushButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/pushbutton.go
+++ b/declarative/pushbutton.go
@@ -13,6 +13,7 @@ import (
 type PushButton struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type PushButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/radiobutton.go
+++ b/declarative/radiobutton.go
@@ -13,6 +13,7 @@ import (
 type RadioButton struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type RadioButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/radiobutton.go
+++ b/declarative/radiobutton.go
@@ -33,6 +33,7 @@ type RadioButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/radiobuttongroupbox.go
+++ b/declarative/radiobuttongroupbox.go
@@ -13,6 +13,7 @@ import (
 type RadioButtonGroupBox struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type RadioButtonGroupBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/radiobuttongroupbox.go
+++ b/declarative/radiobuttongroupbox.go
@@ -33,6 +33,7 @@ type RadioButtonGroupBox struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/scrollview.go
+++ b/declarative/scrollview.go
@@ -33,6 +33,7 @@ type ScrollView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/scrollview.go
+++ b/declarative/scrollview.go
@@ -13,6 +13,7 @@ import (
 type ScrollView struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type ScrollView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/separator.go
+++ b/declarative/separator.go
@@ -33,6 +33,7 @@ type HSeparator struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 
@@ -85,6 +86,7 @@ type VSeparator struct {
 	Persistent       bool
 	ToolTipText      Property
 	Visible          Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/separator.go
+++ b/declarative/separator.go
@@ -13,6 +13,7 @@ import (
 type HSeparator struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type HSeparator struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 
@@ -69,6 +69,7 @@ func (s HSeparator) Create(builder *Builder) error {
 type VSeparator struct {
 	// Window
 
+	Accessibility      Accessibility
 	ContextMenuItems []MenuItem
 	Enabled          Property
 	Font             Font
@@ -86,7 +87,6 @@ type VSeparator struct {
 	Persistent       bool
 	ToolTipText      Property
 	Visible          Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/slider.go
+++ b/declarative/slider.go
@@ -13,6 +13,7 @@ import (
 type Slider struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type Slider struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/slider.go
+++ b/declarative/slider.go
@@ -33,6 +33,7 @@ type Slider struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/splitbutton.go
+++ b/declarative/splitbutton.go
@@ -13,6 +13,7 @@ import (
 type SplitButton struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type SplitButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/splitbutton.go
+++ b/declarative/splitbutton.go
@@ -33,6 +33,7 @@ type SplitButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/splitter.go
+++ b/declarative/splitter.go
@@ -33,6 +33,7 @@ type HSplitter struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 
@@ -105,6 +106,7 @@ type VSplitter struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/splitter.go
+++ b/declarative/splitter.go
@@ -13,6 +13,7 @@ import (
 type HSplitter struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type HSplitter struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 
@@ -87,6 +87,7 @@ func (s HSplitter) Create(builder *Builder) error {
 type VSplitter struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	Enabled            Property
@@ -106,7 +107,6 @@ type VSplitter struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tableview.go
+++ b/declarative/tableview.go
@@ -34,6 +34,7 @@ type TableView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tableview.go
+++ b/declarative/tableview.go
@@ -14,6 +14,7 @@ import (
 type TableView struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -34,7 +35,6 @@ type TableView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tabpage.go
+++ b/declarative/tabpage.go
@@ -13,6 +13,7 @@ import (
 type TabPage struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type TabPage struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tabpage.go
+++ b/declarative/tabpage.go
@@ -33,6 +33,7 @@ type TabPage struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tabwidget.go
+++ b/declarative/tabwidget.go
@@ -33,6 +33,7 @@ type TabWidget struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/tabwidget.go
+++ b/declarative/tabwidget.go
@@ -13,6 +13,7 @@ import (
 type TabWidget struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type TabWidget struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/textedit.go
+++ b/declarative/textedit.go
@@ -34,6 +34,7 @@ type TextEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/textedit.go
+++ b/declarative/textedit.go
@@ -14,6 +14,7 @@ import (
 type TextEdit struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -34,7 +35,6 @@ type TextEdit struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/textlabel.go
+++ b/declarative/textlabel.go
@@ -48,6 +48,7 @@ type TextLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/textlabel.go
+++ b/declarative/textlabel.go
@@ -28,6 +28,7 @@ const (
 type TextLabel struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -48,7 +49,6 @@ type TextLabel struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/toolbar.go
+++ b/declarative/toolbar.go
@@ -22,6 +22,7 @@ const (
 type ToolBar struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -42,7 +43,6 @@ type ToolBar struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/toolbar.go
+++ b/declarative/toolbar.go
@@ -42,6 +42,7 @@ type ToolBar struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/toolbutton.go
+++ b/declarative/toolbutton.go
@@ -33,6 +33,7 @@ type ToolButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/toolbutton.go
+++ b/declarative/toolbutton.go
@@ -13,6 +13,7 @@ import (
 type ToolButton struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type ToolButton struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/treeview.go
+++ b/declarative/treeview.go
@@ -33,6 +33,7 @@ type TreeView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/treeview.go
+++ b/declarative/treeview.go
@@ -13,6 +13,7 @@ import (
 type TreeView struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type TreeView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/webview.go
+++ b/declarative/webview.go
@@ -33,6 +33,7 @@ type WebView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
+	Accessibility      Accessibility
 
 	// Widget
 

--- a/declarative/webview.go
+++ b/declarative/webview.go
@@ -13,6 +13,7 @@ import (
 type WebView struct {
 	// Window
 
+	Accessibility      Accessibility
 	Background         Brush
 	ContextMenuItems   []MenuItem
 	DoubleBuffering    bool
@@ -33,7 +34,6 @@ type WebView struct {
 	RightToLeftReading bool
 	ToolTipText        Property
 	Visible            Property
-	Accessibility      Accessibility
 
 	// Widget
 

--- a/examples/actions/actions.go
+++ b/examples/actions/actions.go
@@ -140,6 +140,9 @@ func main() {
 				Name:    "enabledCB",
 				Text:    "Open / Special Enabled",
 				Checked: true,
+				Accessibility: Accessibility{
+					Help: "Enables Open and Special",
+				},
 			},
 			CheckBox{
 				Name:    "openHiddenCB",
@@ -157,6 +160,9 @@ func main() {
 					} else {
 						toggleSpecialModePB.SetText("Enable Special Mode")
 					}
+				},
+				Accessibility: Accessibility{
+					Help: "Toggles special mode",
 				},
 			},
 		},

--- a/window.go
+++ b/window.go
@@ -436,6 +436,7 @@ type WindowBase struct {
 	suspended                 bool
 	visible                   bool
 	enabled                   bool
+	acc                       *Accessibility
 }
 
 var (
@@ -767,58 +768,13 @@ func ensureWindowLongBits(hwnd win.HWND, index int32, bits uint32, set bool) err
 	return setAndClearWindowLongBits(hwnd, index, setBits, clearBits)
 }
 
-// SetAccAccelerator sets window accelerator name using Dynamic Annotation.
-func (wb *WindowBase) SetAccAccelerator(acc string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_KEYBOARDSHORTCUT, win.EVENT_OBJECT_ACCELERATORCHANGE, acc)
-}
-
-// SetAccDefaultAction sets window default action using Dynamic Annotation.
-func (wb *WindowBase) SetAccDefaultAction(defAction string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_DEFAULTACTION, win.EVENT_OBJECT_DEFACTIONCHANGE, defAction)
-}
-
-// SetAccDescription sets window description using Dynamic Annotation.
-func (wb *WindowBase) SetAccDescription(acc string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_DESCRIPTION, win.EVENT_OBJECT_DESCRIPTIONCHANGE, acc)
-}
-
-// SetAccHelp sets window help using Dynamic Annotation.
-func (wb *WindowBase) SetAccHelp(help string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_HELP, win.EVENT_OBJECT_HELPCHANGE, help)
-}
-
-// SetAccName sets window name using Dynamic Annotation.
-func (wb *WindowBase) SetAccName(name string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_NAME, win.EVENT_OBJECT_NAMECHANGE, name)
-}
-
-// SetAccRole sets window role using Dynamic Annotation. The role must be set when the window is
-// created and is not to be modified later.
-func (wb *WindowBase) SetAccRole(role AccRole) error {
-	return wb.group.accSetPropertyInt(wb.hWnd, &win.PROPID_ACC_ROLE, 0, int32(role))
-}
-
-// SetAccRoleMap sets window role map using Dynamic Annotation. The role map must be set when the
-// window is created and is not to be modified later.
-func (wb *WindowBase) SetAccRoleMap(roleMap string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_ROLEMAP, 0, roleMap)
-}
-
-// SetAccState sets window state using Dynamic Annotation.
-func (wb *WindowBase) SetAccState(state AccState) error {
-	return wb.group.accSetPropertyInt(wb.hWnd, &win.PROPID_ACC_STATE, win.EVENT_OBJECT_STATECHANGE, int32(state))
-}
-
-// SetAccStateMap sets window state map using Dynamic Annotation. The state map must be set when
-// the window is created and is not to be modified later.
-func (wb *WindowBase) SetAccStateMap(stateMap string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_STATEMAP, 0, stateMap)
-}
-
-// SetAccValueMap sets window value map using Dynamic Annotation. The value map must be set when
-// the window is created and is not to be modified later.
-func (wb *WindowBase) SetAccValueMap(valueMap string) error {
-	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_VALUEMAP, 0, valueMap)
+// Accessibility returns the accessibility object used to set Dynamic Annotation properties of the
+// window.
+func (wb *WindowBase) Accessibility() *Accessibility {
+	if wb.acc == nil {
+		wb.acc = &Accessibility{wb: wb}
+	}
+	return wb.acc
 }
 
 // Handle returns the window handle of the Window.

--- a/window.go
+++ b/window.go
@@ -35,6 +35,10 @@ type Window interface {
 	// struct that implements most operations common to all windows.
 	AsWindowBase() *WindowBase
 
+	// Accessibility returns the accessibility object used to set Dynamic Annotation properties of the
+	// window.
+	Accessibility() *Accessibility
+
 	// Background returns the background Brush of the Window.
 	//
 	// By default this is nil.

--- a/window.go
+++ b/window.go
@@ -767,6 +767,60 @@ func ensureWindowLongBits(hwnd win.HWND, index int32, bits uint32, set bool) err
 	return setAndClearWindowLongBits(hwnd, index, setBits, clearBits)
 }
 
+// SetAccAccelerator sets window accelerator name using Dynamic Annotation.
+func (wb *WindowBase) SetAccAccelerator(acc string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_KEYBOARDSHORTCUT, win.EVENT_OBJECT_ACCELERATORCHANGE, acc)
+}
+
+// SetAccDefaultAction sets window default action using Dynamic Annotation.
+func (wb *WindowBase) SetAccDefaultAction(defAction string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_DEFAULTACTION, win.EVENT_OBJECT_DEFACTIONCHANGE, defAction)
+}
+
+// SetAccDescription sets window description using Dynamic Annotation.
+func (wb *WindowBase) SetAccDescription(acc string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_DESCRIPTION, win.EVENT_OBJECT_DESCRIPTIONCHANGE, acc)
+}
+
+// SetAccHelp sets window help using Dynamic Annotation.
+func (wb *WindowBase) SetAccHelp(help string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_HELP, win.EVENT_OBJECT_HELPCHANGE, help)
+}
+
+// SetAccName sets window name using Dynamic Annotation.
+func (wb *WindowBase) SetAccName(name string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_NAME, win.EVENT_OBJECT_NAMECHANGE, name)
+}
+
+// SetAccRole sets window role using Dynamic Annotation. The role must be set when the window is
+// created and is not to be modified later.
+func (wb *WindowBase) SetAccRole(role AccRole) error {
+	return wb.group.accSetPropertyInt(wb.hWnd, &win.PROPID_ACC_ROLE, 0, int32(role))
+}
+
+// SetAccRoleMap sets window role map using Dynamic Annotation. The role map must be set when the
+// window is created and is not to be modified later.
+func (wb *WindowBase) SetAccRoleMap(roleMap string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_ROLEMAP, 0, roleMap)
+}
+
+// SetAccState sets window state using Dynamic Annotation.
+func (wb *WindowBase) SetAccState(state AccState) error {
+	return wb.group.accSetPropertyInt(wb.hWnd, &win.PROPID_ACC_STATE, win.EVENT_OBJECT_STATECHANGE, int32(state))
+}
+
+// SetAccStateMap sets window state map using Dynamic Annotation. The state map must be set when
+// the window is created and is not to be modified later.
+func (wb *WindowBase) SetAccStateMap(stateMap string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_STATEMAP, 0, stateMap)
+}
+
+// SetAccValueMap sets window value map using Dynamic Annotation. The value map must be set when
+// the window is created and is not to be modified later.
+func (wb *WindowBase) SetAccValueMap(valueMap string) error {
+	return wb.group.accSetPropertyStr(wb.hWnd, &win.PROPID_ACC_VALUEMAP, 0, valueMap)
+}
+
 // Handle returns the window handle of the Window.
 func (wb *WindowBase) Handle() win.HWND {
 	return wb.hWnd
@@ -858,6 +912,7 @@ func (wb *WindowBase) Dispose() {
 	}
 
 	if hWnd != 0 {
+		wb.group.accClearHwndProps(wb.hWnd)
 		wb.group.Done()
 	}
 }

--- a/windowgroup.go
+++ b/windowgroup.go
@@ -126,55 +126,20 @@ func (g *WindowGroup) Refs() int {
 	return g.refs
 }
 
-// accCreatePropServices creates an instance of CLSID_AccPropServices class or returns existing one
-// if already created.
-func (g *WindowGroup) accCreatePropServices() (*win.IAccPropServices, error) {
+// AccessibilityServices returns an instance of CLSID_AccPropServices class.
+func (g *WindowGroup) accessibilityServices() *win.IAccPropServices {
 	if g.accPropServices != nil {
-		return g.accPropServices, nil
+		return g.accPropServices
 	}
 
 	var accPropServices *win.IAccPropServices
 	hr := win.CoCreateInstance(&win.CLSID_AccPropServices, nil, win.CLSCTX_ALL, &win.IID_IAccPropServices, (*unsafe.Pointer)(unsafe.Pointer(&accPropServices)))
 	if win.FAILED(hr) {
-		return nil, errorFromHRESULT("CoCreateInstance(CLSID_AccPropServices)", hr)
+		return nil
 	}
 
 	g.accPropServices = accPropServices
-	return accPropServices, nil
-}
-
-// accSetPropertyInt sets integer window property for Dynamic Annotation.
-func (g *WindowGroup) accSetPropertyInt(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value int32) error {
-	accPropServices, err := g.accCreatePropServices()
-	if err != nil {
-		return err
-	}
-	var v win.VARIANT
-	v.SetLong(value)
-	hr := accPropServices.SetHwndProp(hwnd, win.OBJID_CLIENT, win.CHILDID_SELF, idProp, &v)
-	if win.FAILED(hr) {
-		return errorFromHRESULT("IAccPropServices.SetHwndProp", hr)
-	}
-	if win.EVENT_OBJECT_CREATE <= event && event <= win.EVENT_OBJECT_END {
-		win.NotifyWinEvent(event, hwnd, win.OBJID_CLIENT, win.CHILDID_SELF)
-	}
-	return nil
-}
-
-// accSetPropertyInt sets string window property for Dynamic Annotation.
-func (g *WindowGroup) accSetPropertyStr(hwnd win.HWND, idProp *win.MSAAPROPID, event uint32, value string) error {
-	accPropServices, err := g.accCreatePropServices()
-	if err != nil {
-		return err
-	}
-	hr := accPropServices.SetHwndPropStr(hwnd, win.OBJID_CLIENT, win.CHILDID_SELF, idProp, value)
-	if win.FAILED(hr) {
-		return errorFromHRESULT("IAccPropServices.SetHwndPropStr", hr)
-	}
-	if win.EVENT_OBJECT_CREATE <= event && event <= win.EVENT_OBJECT_END {
-		win.NotifyWinEvent(event, hwnd, win.OBJID_CLIENT, win.CHILDID_SELF)
-	}
-	return nil
+	return accPropServices
 }
 
 // accPropIds is a static list of accessibility properties user (may) set for a window


### PR DESCRIPTION
This PR aims to address as many suggestions reported in #623 as possible.

@lxn, please do not merge this PR before @zx2c4 takes a look at it. It is much easier for me to have this PR open and fix things inside it to make everyone happy, than reverting master back and forth.

- HRESULTs are no longer returned to the clients.
- All win.SOMETHING_UGLY constants have been redeclared in lxn/walk and created as enums. Like MessageBox does it.
- Constants were declared in accessibility.go to reduce clutter in windows.go.
- I am not sure about keeping Dynamic Annotation methods in the Window interface, but Dynamic Annotation properties are bound to each HWND like window text and other GDI properties. If you can't see them, it doesn't mean they are less important.
- All windows of the same windows group now share the same CLSID_AccPropServices object.
- OLE/COM initialization is no longer required/expected from the client. It is initialized in WindowGroup automatically. Like folder selection dialog or WebView control do. Unlike ProgressIndicator does not.