### PR TITLE
form: abuse DPI handling for icon scaling better

### DIFF
--- a/form.go
+++ b/form.go
@@ -522,18 +522,17 @@ func (fb *FormBase) SetIcon(icon Image) error {
 	if icon != nil {
 		dpi := fb.DPI()
 		size96dpi := icon.Size()
-		scale := float64(dpi) / float64(size96dpi.Height)
 
-		smallHeight96dpi := int(win.GetSystemMetricsForDpi(win.SM_CYSMICON, 96))
-		smallDPI := int(math.Round(float64(smallHeight96dpi) * scale))
+		smallHeight := int(win.GetSystemMetricsForDpi(win.SM_CYSMICON, uint32(dpi)))
+		smallDPI := int(math.Round(float64(smallHeight) / float64(size96dpi.Height) * 96.0))
 		smallIcon, err := iconCache.Icon(icon, smallDPI)
 		if err != nil {
 			return err
 		}
 		hIconSmall = uintptr(smallIcon.handleForDPI(smallDPI))
 
-		bigHeight96dpi := int(win.GetSystemMetricsForDpi(win.SM_CYICON, 96))
-		bigDPI := int(math.Round(float64(bigHeight96dpi) * scale))
+		bigHeight := int(win.GetSystemMetricsForDpi(win.SM_CYICON, uint32(dpi)))
+		bigDPI := int(math.Round(float64(bigHeight) / float64(size96dpi.Height) * 96.0))
 		bigIcon, err := iconCache.Icon(icon, bigDPI)
 		if err != nil {
 			return err


### PR DESCRIPTION
Since Windows 7 and Windows 8 assume that the second parameter to
GetSystemMetricsForDpi is always DPI(), it's wrong to pass it a constant
96. So instead we abuse the DPI handling a bit differently, determining
the scale based on the output.

CC @rozmansi 