### PR TITLE
Fix imageviewer example

### DIFF
--- a/examples/imageviewer/imageviewer.go
+++ b/examples/imageviewer/imageviewer.go
@@ -49,15 +49,18 @@ func main() {
 				},
 			},
 		},
-		ToolBarItems: []MenuItem{
-			ActionRef{&openAction},
-		},
 		MinSize: Size{320, 240},
 		Size:    Size{800, 600},
 		Layout:  VBox{MarginsZero: true},
 		Children: []Widget{
 			TabWidget{
 				AssignTo: &mw.tabWidget,
+				Pages: []TabPage{
+					TabPage{
+						Layout: HBox{},
+						Name:   "placeholder",
+					},
+				},
 			},
 		},
 	}.Run()); err != nil {
@@ -146,6 +149,10 @@ func (mw *MyMainWindow) openImage() error {
 	}
 
 	succeeded = true
+
+	if mw.tabWidget.Pages().At(0).Name() == "placeholder" {
+		mw.tabWidget.Pages().Remove(mw.tabWidget.Pages().At(0))
+	}
 
 	return nil
 }


### PR DESCRIPTION
As reported in https://github.com/lxn/walk/issues/671, the imageviewer example is broken.
This makes it work by:
- Adding a Pages array to TabWidget which contains a TabPage. This keeps the program from crashing.
- Giving that page a name and deleting it when you load the first image, just to clean up the above hack.
- Deleting the ToolBar. It obscured the tab names and wasn't part of the example, so I killed it.