### PR TITLE
Publish event as selected index changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Alexander Neumann <an2048@gmail.com>
 Aman Gupta <aman@tmm1.net>
 Anthony Dong <adongy@users.noreply.github.com>
 Attila Tajti <attila.tajti@gmail.com>
+Audrius Karabanovas <audrius@karabanovas.net>
 Benny Siegert <bsiegert@gmail.com>
 Cary Cherng <ccherng@gmail.com>
 Dmitry Bagdanov <dimbojob@gmail.com>

--- a/combobox.go
+++ b/combobox.go
@@ -667,6 +667,7 @@ func (cb *ComboBox) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 
 		case win.CBN_SELCHANGE:
 			cb.selChangeIndex = selIndex
+			cb.currentIndexChangedPublisher.Publish()
 
 		case win.CBN_SELENDCANCEL:
 			if cb.selChangeIndex != -1 {


### PR DESCRIPTION
Currently `OnCurrentIndexChanged` not triggered when you change value for `win.CBN_SELCHANGE`