### PR TITLE
action: provide a Menu() getter

### DIFF
--- a/action.go
+++ b/action.go
@@ -95,6 +95,10 @@ func (a *Action) release() {
 	}
 }
 
+func (a *Action) Menu() *Menu {
+	return a.menu
+}
+
 func (a *Action) Checkable() bool {
 	return a.checkable
 }


### PR DESCRIPTION
It's useful for abstractions to be able to get the Menu back out of an
action after putting it in, so this commit adds a simple accessor for
it.