### PR TITLE
MainWindow: fix ignore WM_SIZE causes statusbar invisible when created

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ Simon Rozman <simon@rozman.si>
 Tim Dufrane <tim.dufrane@gmail.com>
 Vincent Vanackere <vincent.vanackere@gmail.com>
 xoviat <xoviat@gmail.com>
+evangwt <evangwt@gmail.com>

--- a/mainwindow.go
+++ b/mainwindow.go
@@ -220,20 +220,27 @@ func (mw *MainWindow) SetFullscreen(fullscreen bool) error {
 
 func (mw *MainWindow) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) uintptr {
 	switch msg {
-	case win.WM_WINDOWPOSCHANGED:
-		wp := (*win.WINDOWPOS)(unsafe.Pointer(lParam))
-
-		if wp.Flags&win.SWP_NOSIZE != 0 {
-			break
+	case win.WM_WINDOWPOSCHANGED, win.WM_SIZE:
+		if win.WM_WINDOWPOSCHANGED == msg {
+			wp := (*win.WINDOWPOS)(unsafe.Pointer(lParam))
+			if wp.Flags&win.SWP_NOSIZE != 0 {
+				break
+			}
 		}
 
 		cb := mw.ClientBoundsPixels()
 
 		if mw.toolBar != nil {
-			mw.toolBar.SetBoundsPixels(Rectangle{0, 0, cb.Width, mw.toolBar.HeightPixels()})
+			bounds := Rectangle{0, 0, cb.Width, mw.toolBar.HeightPixels()}
+			if mw.toolBar.BoundsPixels() != bounds {
+				mw.toolBar.SetBoundsPixels(bounds)
+			}
 		}
 
-		mw.statusBar.SetBoundsPixels(Rectangle{0, cb.Y + cb.Height, cb.Width, mw.statusBar.HeightPixels()})
+		bounds := Rectangle{0, cb.Y + cb.Height, cb.Width, mw.statusBar.HeightPixels()}
+		if mw.statusBar.BoundsPixels() != bounds {
+			mw.statusBar.SetBoundsPixels(bounds)
+		}
 
 	case win.WM_INITMENUPOPUP:
 		mw.menu.updateItemsWithImageForWindow(mw)


### PR DESCRIPTION
Fix this [issue](https://github.com/lxn/walk/issues/720)

As @jackyzy823 mentioned that this [commit](https://github.com/lxn/walk/commit/d8ada91af705b66ffc738f77a8fa3ae110ac2afe) introduced the bug. And I find this  [line](https://github.com/lxn/walk/commit/d8ada91af705b66ffc738f77a8fa3ae110ac2afe?branch=d8ada91af705b66ffc738f77a8fa3ae110ac2afe&diff=unified#r45045435) is the key.

Here are some additional remark from MSDN [doc](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-windowposchanged)

> By default, the DefWindowProc function sends the WM_SIZE and WM_MOVE messages to the window. The WM_SIZE and WM_MOVE messages are not sent if an application handles the WM_WINDOWPOSCHANGED message without calling DefWindowProc. It is more efficient to perform any move or size change processing during the WM_WINDOWPOSCHANGED message without calling DefWindowProc.