### PR TITLE
notifyicon: recreate when explorer.exe crashes

### DIFF
--- a/form.go
+++ b/form.go
@@ -32,12 +32,14 @@ var (
 
 	syncMsgId                 uint32
 	taskbarButtonCreatedMsgId uint32
+	taskbarCreatedMsgId       uint32
 )
 
 func init() {
 	AppendToWalkInit(func() {
 		syncMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("WalkSync"))
 		taskbarButtonCreatedMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("TaskbarButtonCreated"))
+		taskbarCreatedMsgId = win.RegisterWindowMessage(syscall.StringToUTF16Ptr("TaskbarCreated"))
 	})
 }
 
@@ -880,6 +882,11 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 		// Check that the OS is Win 7 or later (Win 7 is v6.1).
 		if fb.progressIndicator == nil && (major > 6 || (major == 6 && minor > 0)) {
 			fb.progressIndicator, _ = newTaskbarList3(fb.hWnd)
+		}
+
+	case taskbarCreatedMsgId:
+		for ni := range notifyIcons {
+			ni.readdToTaskbar()
 		}
 	}
 


### PR DESCRIPTION
According to [MSDN](https://docs.microsoft.com/en-us/windows/win32/shell/taskbar?redirectedfrom=MSDN#taskbar-creation-notification), we receive a TaskbarCreated message after Windows recreates the taskbar, which can happen if explorer.exe crashes or even if the DPI changes. When this happens, we're supposed to create a new notify icon; otherwise the previous one is nowhere to be found. This commit listens for that message and recreates the state accordingly.

Reported-by: @vmsh0
Diagnosed-by: @rozmansi 