### PR TITLE
Empty Layout nil avoidance

### DIFF
--- a/declarative/dialog.go
+++ b/declarative/dialog.go
@@ -132,6 +132,12 @@ func (d Dialog) Create(owner walk.Form) error {
 			}
 		}
 
+		if d.Layout == nil {
+			if err := w.SetLayout(walk.NewVBoxLayout()); err != nil {
+				return err
+			}
+		}
+
 		if d.DefaultButton != nil {
 			if err := w.SetDefaultButton(*d.DefaultButton); err != nil {
 				return err

--- a/declarative/mainwindow.go
+++ b/declarative/mainwindow.go
@@ -176,6 +176,12 @@ func (mw MainWindow) Create() error {
 		// 	*mw.AssignTo = w
 		// }
 
+		if mw.Layout == nil {
+			if err := w.SetLayout(walk.NewVBoxLayout()); err != nil {
+				return err
+			}
+		}
+
 		if mw.Expressions != nil {
 			for name, expr := range mw.Expressions() {
 				builder.expressions[name] = expr


### PR DESCRIPTION
If you don't describe the layout when creating a window, you will get a runtime error. 
I put VBOX as the initial value to avoid nil in Mainwindow and Dialog.