### PR TITLE
fixing adding item into treeview if item not have parent item

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -175,12 +175,16 @@ func (tv *TreeView) SetModel(model TreeModel) error {
 
 			var hInsertAfter win.HTREEITEM
 			parent := item.Parent()
-			for i := parent.ChildCount() - 1; i >= 0; i-- {
-				if parent.ChildAt(i) == item {
-					if i > 0 {
-						hInsertAfter = tv.item2Info[parent.ChildAt(i-1)].handle
-					} else {
-						hInsertAfter = win.TVI_FIRST
+			if parent == nil {
+				hInsertAfter = win.TVI_LAST
+			} else {
+				for i := parent.ChildCount() - 1; i >= 0; i-- {
+					if parent.ChildAt(i) == item {
+						if i > 0 {
+							hInsertAfter = tv.item2Info[parent.ChildAt(i-1)].handle
+						} else {
+							hInsertAfter = win.TVI_FIRST
+						}
 					}
 				}
 			}


### PR DESCRIPTION
I tried add new item that not have parent in to treeview but get error

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x20 pc=0x6136d5]

goroutine 1 [running, locked to thread]:
github.com/lxn/walk.(*TreeView).SetModel.func3(0x76d280, 0xc000006188)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/treeview.go:178 +0xc5
github.com/lxn/walk.(*TreeItemEventPublisher).Publish(0xc0000a60a0, 0x76d280, 0xc000006188)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/treeitemevent.go:55 +0x96
github.com/lxn/walk.(*TreeModelBase).PublishItemInserted(...)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/models.go:704
main.(*UserInterface).showCreateFolderDialog.func1()
        C:/Users/dedal.qq/Procect/qclient/userInterface_windows.go:84 +0x1bc
github.com/lxn/walk.(*EventPublisher).Publish(0xc00014c330)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/event.go:71 +0xaf
github.com/lxn/walk.(*Button).raiseClicked(...)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:195
github.com/lxn/walk.(*Button).WndProc(0xc00014c000, 0x308c8, 0x111, 0x8, 0x400842, 0xab7a554367bfc007)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:210 +0xb8
github.com/lxn/walk.(*PushButton).WndProc(0xc00014c000, 0x308c8, 0x111, 0x8, 0x400842, 0x411831)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/pushbutton.go:115 +0x6e
github.com/lxn/walk.(*ContainerBase).WndProc(0xc0000c3880, 0x308c8, 0x111, 0x8, 0x400842, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/container.go:345 +0x55b
github.com/lxn/walk.defaultWndProc(0x308c8, 0x111, 0x8, 0x400842, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2159 +0xf0
syscall.Syscall6(0x7ffcb9715860, 0x5, 0x7ffcacd6da30, 0x400842, 0x202, 0x0, 0xf0028, 0x0, 0x0, 0x0, ...)
        C:/go/src/runtime/syscall_windows.go:201 +0xfa
github.com/lxn/win.CallWindowProc(0x7ffcacd6da30, 0x400842, 0x202, 0x0, 0xf0028, 0x5)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/win@v0.0.0-20210218163916-a377121e959e/user32.go:2138 +0x8f
github.com/lxn/walk.(*WindowBase).WndProc(0xc00014c000, 0x400842, 0x202, 0x0, 0xf0028, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2511 +0x1eb
github.com/lxn/walk.(*Button).WndProc(0xc00014c000, 0x400842, 0x202, 0x0, 0xf0028, 0xab7a554367bfc007)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:218 +0x8c
github.com/lxn/walk.(*PushButton).WndProc(0xc00014c000, 0x400842, 0x202, 0x0, 0xf0028, 0xc000087f58)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/pushbutton.go:115 +0x6e
github.com/lxn/walk.defaultWndProc(0x400842, 0x202, 0x0, 0xf0028, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2159 +0xf0
syscall.Syscall(0x7ffcb9716b30, 0x2, 0x1208a4, 0xf295e0, 0x0, 0x0, 0x0, 0x0)
        C:/go/src/runtime/syscall_windows.go:188 +0xfa
github.com/lxn/win.IsDialogMessage(0x1208a4, 0xf295e0, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/win@v0.0.0-20210218163916-a377121e959e/user32.go:2834 +0x72
github.com/lxn/walk.(*FormBase).mainLoop(0xc0000bac00, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/mainloop_default.go:35 +0xe2
github.com/lxn/walk.(*FormBase).Run(0xc0000bac00, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/form.go:375 +0xd5
github.com/lxn/walk.(*Dialog).Run(0xc0000bac00, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/dialog.go:236 +0x42
github.com/lxn/walk/declarative.Dialog.Run(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/declarative/dialog.go:182 +0x103
main.(*UserInterface).showCreateFolderDialog(0xc000004700)
        C:/Users/dedal.qq/Procect/qclient/userInterface_windows.go:92 +0x457
github.com/lxn/walk.(*EventPublisher).Publish(0xc0000ba730)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/event.go:71 +0xaf
github.com/lxn/walk.(*Button).raiseClicked(...)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:195
github.com/lxn/walk.(*Button).WndProc(0xc0000ba400, 0x11089a, 0x111, 0x1, 0x608ac, 0x1593d067e607e885)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:210 +0xb8
github.com/lxn/walk.(*PushButton).WndProc(0xc0000ba400, 0x11089a, 0x111, 0x1, 0x608ac, 0x411831)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/pushbutton.go:115 +0x6e
github.com/lxn/walk.(*ContainerBase).WndProc(0xc0000c2e00, 0x11089a, 0x111, 0x1, 0x608ac, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/container.go:345 +0x55b
github.com/lxn/walk.defaultWndProc(0x11089a, 0x111, 0x1, 0x608ac, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2159 +0xf0
syscall.Syscall6(0x7ffcb9715860, 0x5, 0x7ffcacd6da30, 0x608ac, 0x202, 0x0, 0xd0058, 0x0, 0x0, 0x0, ...)
        C:/go/src/runtime/syscall_windows.go:201 +0xfa
github.com/lxn/win.CallWindowProc(0x7ffcacd6da30, 0x608ac, 0x202, 0x0, 0xd0058, 0x5)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/win@v0.0.0-20210218163916-a377121e959e/user32.go:2138 +0x8f
github.com/lxn/walk.(*WindowBase).WndProc(0xc0000ba400, 0x608ac, 0xc000000202, 0x0, 0xd0058, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2511 +0x1eb
github.com/lxn/walk.(*Button).WndProc(0xc0000ba400, 0x608ac, 0x202, 0x0, 0xd0058, 0x1593d067e607e885)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/button.go:218 +0x8c
github.com/lxn/walk.(*PushButton).WndProc(0xc0000ba400, 0x608ac, 0x202, 0x0, 0xd0058, 0xc000089af8)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/pushbutton.go:115 +0x6e
github.com/lxn/walk.defaultWndProc(0x608ac, 0x202, 0x0, 0xd0058, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/window.go:2159 +0xf0
syscall.Syscall(0x7ffcb9716b30, 0x2, 0x5f0490, 0xedb140, 0x0, 0x0, 0x0, 0x0)
        C:/go/src/runtime/syscall_windows.go:188 +0xfa
github.com/lxn/win.IsDialogMessage(0x5f0490, 0xedb140, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/win@v0.0.0-20210218163916-a377121e959e/user32.go:2834 +0x72
github.com/lxn/walk.(*FormBase).mainLoop(0xc0000ba000, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/mainloop_default.go:35 +0xe2
github.com/lxn/walk.(*FormBase).Run(0xc0000ba000, 0x0)
        C:/Users/dedal.qq/go/pkg/mod/github.com/lxn/walk@v0.0.0-20210112085537-c389da54e794/form.go:375 +0xd5
main.(*UserInterface).run(0xc000004700, 0xc000004700, 0x0)
        C:/Users/dedal.qq/Procect/qclient/userInterface_windows.go:178 +0x69
main.main()
        C:/Users/dedal.qq/Procect/qclient/main.go:358 +0xed
```

This patch fixed my problem. I hope it's a right patch and will be useful =)